### PR TITLE
feat: tutor-controlled pipeline with demand-driven research

### DIFF
--- a/.claude/workflows/curriculum-build.js
+++ b/.claude/workflows/curriculum-build.js
@@ -165,7 +165,7 @@ if (!reader?.research) {
   log(`WARNING: No research found at ${researchPath}. Run the research workflow first.`)
 }
 
-const ctx = `Topic: "${topic}"
+let ctx = `Topic: "${topic}"
 Student level: ${level}
 ${audienceContext}
 ${feedback ? `\n## Previous Feedback to Address\n${feedback}` : ''}
@@ -173,6 +173,60 @@ ${reader?.research ? `\n## Research\n${reader.research}` : '(no research availab
 ${reader?.userProfile ? `\n## Student Profile\n${reader.userProfile}` : ''}
 ${reader?.curriculumFormat ? `\n## Curriculum Format Reference\n${reader.curriculumFormat}` : ''}
 ${reader?.teachingMethod ? `\n## Teaching Method Reference\n${reader.teachingMethod}` : ''}`
+
+// ── Cross-topic overlap scan ──────────────────────────────────
+
+const OVERLAP_SCHEMA = {
+  type: 'object',
+  properties: {
+    existingTopics: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          slug: { type: 'string' },
+          topic: { type: 'string' },
+          sharedConcepts: { type: 'array', items: { type: 'string' } },
+          connectionPoints: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['slug', 'topic'],
+      },
+    },
+  },
+  required: ['existingTopics'],
+}
+
+const overlap = await agent(
+  `List all directories under skills/tutor/domains/ (excluding "${slug}").
+For each existing domain directory found, read its concept-map.md and curriculum.json.
+
+Then identify concepts that overlap or connect with the new topic "${topic}".
+
+A "shared concept" is a concept that appears in both the existing domain and would naturally appear in a course on "${topic}" (e.g., "linear programming" might be shared between "optimal transport" and "operations research").
+
+A "connection point" is a specific way the two topics relate — how a concept learned in the existing topic enables or enriches understanding of the new topic (e.g., "Kantorovich duality from optimal-transport provides foundation for understanding LP duality in this course").
+
+If no other domains exist, return {"existingTopics": []}.
+
+Return as JSON.`,
+  { label: 'overlap-scan', phase: 'Read', schema: OVERLAP_SCHEMA }
+)
+
+const crossTopicConnections = (overlap?.existingTopics || []).filter(t => (t.sharedConcepts?.length || 0) > 0 || (t.connectionPoints?.length || 0) > 0)
+
+const overlapContext = crossTopicConnections.length > 0
+  ? '\n## Cross-Topic Connections\nThe student has already studied these related topics:\n' +
+    crossTopicConnections.map(t =>
+      '- **' + t.topic + '** (' + t.slug + '): ' +
+      (t.sharedConcepts?.length ? 'shares concepts [' + t.sharedConcepts.join(', ') + ']' : '') +
+      (t.connectionPoints?.length ? ' — ' + t.connectionPoints.join('; ') : '')
+    ).join('\n')
+  : ''
+
+if (crossTopicConnections.length > 0) {
+  log(`Found ${crossTopicConnections.length} related topic(s) with concept overlap`)
+  ctx = ctx + overlapContext
+}
 
 // ── Phase 2: Design — parallel curriculum design agents ───────
 
@@ -244,6 +298,7 @@ Write teaching notes covering:
 4. **Rabbit holes** — 4-6 fascinating tangential connections to drop in during lessons (with suggested timing)
 5. **Difficulty progression** — Where the difficulty spikes are and how to manage them
 6. **Assessment strategies** — What kinds of exercises work best for each module (multiple choice, open-ended, computation, proof, application)
+7. **Cross-topic connections** — If the context includes cross-topic connections from other domains the student has studied, write a section listing: which previously learned concepts connect to this course, at which lesson to surface each connection, and how to frame it ("You already know X from your study of Y — here it shows up as Z"). If no cross-topic connections exist, omit this section.
 
 Output as markdown. Be specific and practical — a tutor bot will use these notes to adapt its delivery.`,
   },

--- a/.claude/workflows/curriculum-build.js
+++ b/.claude/workflows/curriculum-build.js
@@ -1,7 +1,7 @@
 export const meta = {
   name: 'curriculum-build',
-  description: 'Build a full curriculum from research — modules, lessons, concept map, teaching notes',
-  whenToUse: 'After running the research workflow. Usage: run with args {topic: "optimal transport", level: "intermediate"}',
+  description: 'Build a full curriculum from research — modules, lessons, concept map, teaching notes. Supports patch mode for targeted fixes.',
+  whenToUse: 'After running the research workflow. Usage: run with args {topic: "optimal transport", level: "intermediate"} for full build, or {topic: "...", level: "...", mode: "patch", feedback: "fix lessons 12-15..."} for targeted fixes',
   phases: [
     { title: 'Read', detail: 'Load research document and existing domain data' },
     { title: 'Design', detail: 'Parallel agents design curriculum structure, concept map, and teaching notes' },
@@ -13,10 +13,120 @@ export const meta = {
 const topic = args?.topic
 if (!topic) throw new Error('Missing args.topic — pass {topic: "optimal transport", level: "intermediate"}')
 const level = args?.level || 'intermediate'
+const mode = args?.mode || 'full'
+const feedback = args?.feedback || null
+const audience = args?.audience || null
 
 const slug = topic.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 const domainDir = `skills/tutor/domains/${slug}`
 const researchPath = `${domainDir}/research.md`
+
+const audienceContext = audience
+  ? `\n## Target Audience\n${typeof audience === 'string' ? audience : JSON.stringify(audience, null, 2)}`
+  : ''
+
+// ══════════════════════════════════════════════════════════════
+// PATCH MODE — targeted fixes based on feedback
+// ══════════════════════════════════════════════════════════════
+
+if (mode === 'patch' && feedback) {
+  phase('Read')
+  log(`Patch mode: applying targeted fixes to "${topic}" curriculum`)
+
+  phase('Design')
+
+  const patchResults = await parallel([
+    () => agent(
+      `Read these files:
+- ${domainDir}/curriculum.json
+- ${domainDir}/concept-map.md
+- ${researchPath} (check for any "Targeted Research" sections at the end — these contain new material)
+
+Apply these specific fixes to the curriculum and concept map:
+${feedback}
+${audienceContext}
+
+Rules:
+- Only modify the parts cited in the feedback
+- Preserve all lessons/concepts not mentioned in the feedback
+- If adding new lessons, maintain day number sequence
+- If the feedback mentions thin resources, pull from research.md
+- If new targeted research sections exist, incorporate relevant findings
+- Write the complete corrected curriculum.json back to ${domainDir}/curriculum.json
+- If the concept map needs updates, write the corrected version to ${domainDir}/concept-map.md
+
+Report what you changed at the end of your response.`,
+      { label: 'patch:curriculum', phase: 'Design' }
+    ),
+    () => agent(
+      `Read these files:
+- ${domainDir}/resources.md
+- ${domainDir}/teaching-notes.md
+- ${researchPath} (check for any "Targeted Research" sections at the end — these contain new material)
+
+Apply these specific fixes:
+${feedback}
+${audienceContext}
+
+Rules:
+- Only modify sections cited in the feedback
+- If new targeted research sections exist in research.md, incorporate relevant resources
+- Preserve all content not mentioned in the feedback
+- Write corrected files back to their original paths
+- If a file needs no changes, do not rewrite it
+
+Report what you changed at the end of your response.`,
+      { label: 'patch:resources', phase: 'Design' }
+    ),
+  ])
+
+  // ── Gate — same quality check as full mode ───────────────────
+
+  phase('Gate')
+
+  const GATE_SCHEMA = {
+    type: 'object',
+    properties: {
+      verdict: { type: 'string', enum: ['PROCEED', 'ISSUES'] },
+      sequencing_ok: { type: 'boolean' },
+      coverage_ok: { type: 'boolean' },
+      difficulty_curve_ok: { type: 'boolean' },
+      issues: { type: 'array', items: { type: 'string' } },
+      suggestions: { type: 'array', items: { type: 'string' } },
+    },
+    required: ['verdict', 'issues'],
+  }
+
+  const gate = await agent(
+    `You are a pedagogical quality gate. Review the patched curriculum for "${topic}" (${level} level).
+
+Read these files (they have just been updated by a patch operation):
+- ${domainDir}/curriculum.json
+- ${domainDir}/concept-map.md
+- ${domainDir}/teaching-notes.md
+- ${domainDir}/resources.md
+
+The patch was applied to fix these issues:
+${feedback}
+
+Check:
+1. **Sequencing** — Do prerequisites still come before dependents after the patch?
+2. **Coverage** — Did the patch address the cited issues without breaking other coverage?
+3. **Difficulty curve** — Is the progression still gradual?
+4. **Regression** — Did the patch introduce any new problems?
+5. **Completeness** — Were all items in the feedback actually addressed?
+
+Report as JSON. PROCEED if the patch looks good. ISSUES if there are remaining or new problems.`,
+    { label: 'patch-gate', phase: 'Gate', schema: GATE_SCHEMA }
+  )
+
+  log(`Patch gate: ${gate?.verdict || 'unknown'}, issues: ${gate?.issues?.length || 0}`)
+  return { topic, slug, level, domainDir, mode: 'patch', gate: gate?.verdict, issues: gate?.issues }
+}
+
+// ══════════════════════════════════════════════════════════════
+// FULL MODE — complete curriculum design (default)
+// ══════════════════════════════════════════════════════════════
 
 // ── Phase 1: Read — load research and templates ───────────────
 
@@ -57,6 +167,8 @@ if (!reader?.research) {
 
 const ctx = `Topic: "${topic}"
 Student level: ${level}
+${audienceContext}
+${feedback ? `\n## Previous Feedback to Address\n${feedback}` : ''}
 ${reader?.research ? `\n## Research\n${reader.research}` : '(no research available — generate from knowledge)'}
 ${reader?.userProfile ? `\n## Student Profile\n${reader.userProfile}` : ''}
 ${reader?.curriculumFormat ? `\n## Curriculum Format Reference\n${reader.curriculumFormat}` : ''}
@@ -279,4 +391,4 @@ const writeFiles = await parallel([
 ])
 
 log(`Curriculum written to ${domainDir}/ (4 files)`)
-return { topic, slug, level, domainDir, gate: gate?.verdict, issues: gate?.issues }
+return { topic, slug, level, domainDir, mode: 'full', gate: gate?.verdict, issues: gate?.issues }

--- a/.claude/workflows/dashboard.js
+++ b/.claude/workflows/dashboard.js
@@ -1,0 +1,144 @@
+export const meta = {
+  name: 'dashboard',
+  description: 'Generate an HTML progress dashboard from curriculum data',
+  whenToUse: 'To visualize learning progress across all topics. Usage: run with no args, or {outputPath: "custom/path.html"}',
+  phases: [
+    { title: 'Gather', detail: 'Read progress, curriculum, and QA data' },
+    { title: 'Render', detail: 'Generate self-contained HTML dashboard' },
+  ],
+}
+
+const outputPath = args?.outputPath || 'workspace/tutor/dashboard.html'
+
+// ── Phase 1: Gather ──────────────────────────────────────────
+
+phase('Gather')
+log('Gathering progress and curriculum data')
+
+const DATA_SCHEMA = {
+  type: 'object',
+  properties: {
+    schedule: {
+      type: 'object',
+      properties: {
+        times: { type: 'array', items: { type: 'string' } },
+        timezone: { type: 'string' },
+        pacing: { type: 'string' },
+      },
+    },
+    topics: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          slug: { type: 'string' },
+          name: { type: 'string' },
+          level: { type: 'string' },
+          created: { type: 'string' },
+          totalLessons: { type: 'number' },
+          completedLessons: { type: 'number' },
+          modules: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                total: { type: 'number' },
+                completed: { type: 'number' },
+              },
+              required: ['name', 'total', 'completed'],
+            },
+          },
+          concepts: { type: 'array', items: { type: 'string' } },
+          completedConcepts: { type: 'array', items: { type: 'string' } },
+          qaVerdict: { type: 'string' },
+          qaScore: { type: 'number' },
+          exitCriteria: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['slug', 'name', 'totalLessons', 'completedLessons', 'modules'],
+      },
+    },
+    history: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          date: { type: 'string' },
+          topic: { type: 'string' },
+          lesson: { type: 'number' },
+          engagement: { type: 'string' },
+        },
+      },
+    },
+    streak: { type: 'number' },
+  },
+  required: ['topics', 'history', 'schedule', 'streak'],
+}
+
+const data = await agent(
+  `Read and synthesize all learning data from the OpenTutor workspace.
+
+1. Read workspace/tutor/progress.json for active_topics, schedule, and history.
+
+2. List the directories under skills/tutor/domains/ — each directory is a topic.
+
+3. For EACH topic directory found:
+   a. Read curriculum.json — extract: topic name, slug, student_level, created date, lessons array (count total, count where status === "completed"), group lessons by module field (count total and completed per module), collect all unique concepts across all lessons, collect concepts from completed lessons only, exit_criteria
+   b. Read qa-report.md if it exists — extract the verdict (PASS/PASS_WITH_WARNINGS/FAIL) and overall score
+
+4. From history in progress.json, compute current streak: count consecutive days (ending today or yesterday) that have at least one history entry. If no history, streak is 0.
+
+Return the full data as JSON matching the schema. Include ALL topics found in domains/, not just those in active_topics.`,
+  { label: 'gather', phase: 'Gather', schema: DATA_SCHEMA }
+)
+
+const topicCount = data?.topics?.length || 0
+const totalLessons = (data?.topics || []).reduce((s, t) => s + t.totalLessons, 0)
+const completedLessons = (data?.topics || []).reduce((s, t) => s + t.completedLessons, 0)
+log('Found ' + topicCount + ' topics, ' + totalLessons + ' lessons (' + completedLessons + ' completed)')
+
+// ── Phase 2: Render ──────────────────────────────────────────
+
+phase('Render')
+
+const dataJson = JSON.stringify(data, null, 2)
+
+await agent(
+  'Generate a self-contained HTML dashboard file and write it to ' + outputPath + '.\n\n' +
+  '## Data\n```json\n' + dataJson + '\n```\n\n' +
+  '## Requirements\n\n' +
+  'Build a single HTML file with ALL CSS inline (no external dependencies). The page should include:\n\n' +
+  '### 1. Overview Cards Row\n' +
+  '4 stat cards in a row: Total Topics, Total Lessons, Completion %, Current Streak (days).\n' +
+  'Each card: white background, subtle box-shadow (0 1px 3px rgba(0,0,0,0.12)), rounded corners (8px), padding 24px.\n' +
+  'The number should be large (36px, bold, color #2563eb), label below in small gray text.\n\n' +
+  '### 2. Per-Topic Progress Section\n' +
+  'For each topic: a card with the topic name as header, level badge, created date.\n' +
+  'A full-width progress bar showing completed/total lessons (gradient from #2563eb to #7c3aed).\n' +
+  'Below it: a row of mini progress bars, one per module, with module name labels.\n' +
+  'Show QA verdict badge if available (PASS=#16a34a, PASS_WITH_WARNINGS=#eab308, FAIL=#dc2626).\n' +
+  'List exit criteria as a checklist.\n\n' +
+  '### 3. Concept Mastery Grid\n' +
+  'For each topic: a grid of small pills/tags, one per concept.\n' +
+  'Color: #e2e8f0 (not started), #93c5fd (in completed lesson = learned), #2563eb (mastered if topic 100%).\n' +
+  'Group by topic with topic name as subheader.\n\n' +
+  '### 4. Lesson History Timeline\n' +
+  'Show the most recent 20 history entries as a vertical timeline.\n' +
+  'Each entry: date on the left, topic + lesson number + engagement on the right.\n' +
+  'Use a vertical line with dots. If no history, show "No lessons delivered yet."\n\n' +
+  '### 5. Schedule Info Card\n' +
+  'Show delivery times, timezone, pacing. Clean card format.\n\n' +
+  '### Style Rules\n' +
+  '- Font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif\n' +
+  '- Background: #f8fafc, text: #1e293b\n' +
+  '- Primary: #2563eb, Success: #16a34a, Warning: #eab308, Error: #dc2626\n' +
+  '- Max content width: 960px, centered\n' +
+  '- Responsive: cards wrap on narrow screens (use CSS grid or flexbox with wrap)\n' +
+  '- Page title: "OpenTutor Dashboard"\n' +
+  '- Add a header with the OpenTutor name and a "Generated: (today date)" subtitle\n\n' +
+  'Write the complete HTML file. It must render correctly when opened in a browser.',
+  { label: 'render', phase: 'Render' }
+)
+
+log('Dashboard written to ' + outputPath)
+return { outputPath, topics: topicCount, lessons: totalLessons, completed: completedLessons }

--- a/.claude/workflows/new-topic.js
+++ b/.claude/workflows/new-topic.js
@@ -1,7 +1,7 @@
 export const meta = {
   name: 'new-topic',
   description: 'Tutor-controlled pipeline: survey → audience → build → QA → schedule. The tutor judges each step and decides where more work is needed.',
-  whenToUse: 'When adding a completely new topic. Chains research, curriculum-build, schedule, and curriculum-qa workflows with a tutor quality loop. Usage: run with args {topic: "category theory", level: "intermediate"}',
+  whenToUse: 'When adding a completely new topic. Usage: run with args {topic: "category theory", level: "intermediate"}. For preview only: {topic: "...", dryRun: true}. To resume after escalation: {topic: "...", humanGuidance: "your answer"}',
   phases: [
     { title: 'Survey', detail: 'Broad multi-source research to map the field' },
     { title: 'Audience', detail: 'Tutor assesses target audience and tailors approach' },
@@ -18,6 +18,7 @@ if (!topic) throw new Error('Missing args.topic — pass {topic: "category theor
 const level = args?.level || 'intermediate'
 const timezone = args?.timezone || 'America/New_York'
 const humanGuidance = args?.humanGuidance || null
+const dryRun = args?.dryRun || false
 const slug = topic.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 const domainDir = `skills/tutor/domains/${slug}`
 
@@ -269,6 +270,56 @@ Report as JSON.`,
 tutorMemory.push(`[audience] ${audience?.summary || 'Audience assessment completed.'}`)
 log(`Audience: ${audience?.audience_type || 'unknown'} — ${audience?.goal || 'unknown goal'}`)
 
+// ── Dry-run exit point ────────────────────────────────────────
+
+if (dryRun) {
+  await agent(
+    `Write a preview report to ${domainDir}/preview.md.
+
+Read ${domainDir}/research.md to summarize what was found.
+
+Write the report with this structure:
+
+# Preview: ${topic}
+Generated: (today's date)
+Mode: DRY RUN — no curriculum built yet
+
+## Field Map
+Summarize the major branches/pillars of "${topic}" based on the research.
+List the top 5-8 subtopics that a curriculum would cover.
+
+## Audience Profile
+- **Type**: ${audience?.audience_type || 'unknown'}
+- **Goal**: ${audience?.goal || 'unknown'}
+- **Background**: ${audience?.background || 'unknown'}
+- **Tone**: ${audience?.tone || 'unknown'}
+- **Depth**: ${audience?.depth || 'unknown'}
+- **Time per lesson**: ${audience?.time_commitment || 'unknown'}
+
+## Research Coverage
+Summarize: how many papers found, how many educational resources, any major gaps.
+
+## Tutor Notes
+${tutorMemory.map((m, i) => (i + 1) + '. ' + m).join('\n')}
+
+## Next Step
+To proceed with the full pipeline, run:
+args: {topic: "${topic}", level: "${level}"}`,
+    { label: 'preview', phase: 'Audience' }
+  )
+
+  log(`Dry run complete. Preview written to ${domainDir}/preview.md`)
+  return {
+    topic,
+    slug,
+    level,
+    dryRun: true,
+    audience,
+    researchRounds,
+    tutorMemory,
+  }
+}
+
 // ── Phase 3: Build Curriculum ─────────────────────────────────
 
 phase('Build')
@@ -368,6 +419,45 @@ Then read ${domainDir}/curriculum.json and report:
 - Module count
 - First lesson title`,
   { label: 'register', phase: 'Register' }
+)
+
+// ── Pipeline Report ───────────────────────────────────────────
+
+await agent(
+  `Write a pipeline run report to ${domainDir}/pipeline-report.md.
+
+Read these files to gather final stats:
+- ${domainDir}/curriculum.json — lesson count, module count
+- ${domainDir}/qa-report.md — QA verdict and score (if exists)
+- workspace/tutor/progress.json — schedule details
+
+Write the report with this structure:
+
+# Pipeline Report: ${topic}
+Generated: (today's date)
+
+## Summary
+- **Topic**: ${topic}
+- **Level**: ${level}
+- **Audience**: ${audience?.summary || 'Not assessed'}
+- **Tutor Judgments**: ${tutorMemory.length}
+- **Targeted Research Rounds**: ${researchRounds}/${CAPS.targetedResearch}
+
+## Tutor Decision Log
+${tutorMemory.map((m, i) => (i + 1) + '. ' + m).join('\n')}
+
+## Pipeline Stats
+(Fill in from the files you read)
+- Total lessons:
+- Total modules:
+- QA verdict:
+- QA score:
+- Schedule pacing:
+- Estimated completion:
+
+## Files Generated
+List all files in ${domainDir}/ with their sizes.`,
+  { label: 'report', phase: 'Register' }
 )
 
 log(`Pipeline complete for "${topic}" — ${tutorMemory.length} tutor judgments, ${researchRounds} targeted research rounds`)

--- a/.claude/workflows/new-topic.js
+++ b/.claude/workflows/new-topic.js
@@ -1,12 +1,13 @@
 export const meta = {
   name: 'new-topic',
-  description: 'End-to-end pipeline: research → curriculum build → schedule → QA for a new topic',
-  whenToUse: 'When adding a completely new topic. Chains research, curriculum-build, schedule, and curriculum-qa workflows. Usage: run with args {topic: "category theory", level: "intermediate"}',
+  description: 'Tutor-controlled pipeline: survey → audience → build → QA → schedule. The tutor judges each step and decides where more work is needed.',
+  whenToUse: 'When adding a completely new topic. Chains research, curriculum-build, schedule, and curriculum-qa workflows with a tutor quality loop. Usage: run with args {topic: "category theory", level: "intermediate"}',
   phases: [
-    { title: 'Research', detail: 'Multi-source academic research' },
+    { title: 'Survey', detail: 'Broad multi-source research to map the field' },
+    { title: 'Audience', detail: 'Tutor assesses target audience and tailors approach' },
     { title: 'Build', detail: 'Design curriculum, concept map, teaching notes' },
-    { title: 'Schedule', detail: 'Generate optimal delivery schedule' },
     { title: 'QA', detail: 'Adversarial quality checks' },
+    { title: 'Schedule', detail: 'Generate optimal delivery schedule' },
     { title: 'Register', detail: 'Register topic in progress.json' },
   ],
 }
@@ -16,45 +17,344 @@ if (!topic) throw new Error('Missing args.topic — pass {topic: "category theor
 
 const level = args?.level || 'intermediate'
 const timezone = args?.timezone || 'America/New_York'
+const humanGuidance = args?.humanGuidance || null
 const slug = topic.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 const domainDir = `skills/tutor/domains/${slug}`
 
-// ── Step 1: Research ──────────────────────────────────────────
+// ── Iteration caps ────────────────────────────────────────────
 
-phase('Research')
-log(`Starting full pipeline for "${topic}" (${level})`)
+const CAPS = {
+  targetedResearch: 3,
+  buildRedos: 2,
+  scheduleRedos: 1,
+  qaCycles: 2,
+}
 
-const researchResult = await workflow('research', { topic })
-log(`Research done: ${researchResult?.coverage || '?'}/10 coverage`)
+// ── Tutor state ───────────────────────────────────────────────
 
-// ── Step 2: Build Curriculum ──────────────────────────────────
+const tutorMemory = []
+let researchRounds = 0
+
+if (humanGuidance) {
+  tutorMemory.push(`[human-guidance] The human provided this guidance to resume: ${humanGuidance}`)
+}
+
+// ── Tutor decision schema ─────────────────────────────────────
+
+const TUTOR_DECISION_SCHEMA = {
+  type: 'object',
+  properties: {
+    decision: { type: 'string', enum: ['ADVANCE', 'RESEARCH', 'REDO', 'ESCALATE'] },
+    confidence: { type: 'number' },
+    reasoning: { type: 'string' },
+    research_query: { type: 'string' },
+    redo_feedback: { type: 'string' },
+    redo_targets: { type: 'array', items: { type: 'string' } },
+    escalation_question: { type: 'string' },
+    context_update: { type: 'string' },
+    quality_snapshot: { type: 'string' },
+  },
+  required: ['decision', 'confidence', 'reasoning', 'context_update', 'quality_snapshot'],
+}
+
+// ── Step-specific evaluation criteria ─────────────────────────
+
+const STEP_CRITERIA = {
+  survey: `## Evaluation Criteria: Research Survey
+Read the research document at ${domainDir}/research.md to form your judgment.
+
+- Does the research cover the major branches and subtopics of "${topic}"?
+- Are there enough papers (10+) to support 20-30 lessons?
+- Are educational resources diverse (courses, videos, interactive tools, code)?
+- Are there any critical subtopics with zero coverage that would leave lessons unsupported?
+- Is the field landscape clear enough to structure a course?
+- What are the 4-6 major pillars/branches of this field?`,
+
+  'survey-enriched': `## Evaluation Criteria: Enriched Research
+Read the research document at ${domainDir}/research.md — check especially the "Targeted Research" sections at the end.
+
+- Did the targeted research fill the gaps you identified?
+- Is coverage now sufficient to build a 20-30 lesson curriculum?
+- Are there still critical blind spots that would leave lessons unsupported?`,
+
+  build: `## Evaluation Criteria: Curriculum Build
+Read the domain files to evaluate the actual output:
+- ${domainDir}/curriculum.json
+- ${domainDir}/concept-map.md
+- ${domainDir}/teaching-notes.md
+- ${domainDir}/resources.md
+
+Check:
+- Does the lesson sequence respect concept dependencies from the concept map?
+- Are lesson titles engaging questions or provocations (not dry topic labels)?
+- Is the difficulty progression gradual and appropriate for ${level}?
+- Are there 20-30 lessons with review days every 5-7 lessons?
+- Are there "thin" lessons with only 1 concept and no resources?
+- Does the concept map match the lesson sequence (no orphan concepts)?
+- Are teaching notes specific enough to guide delivery?
+- Are resources real, diverse, and linked to specific lessons?`,
+
+  qa: `## Evaluation Criteria: QA Results
+Read the QA report at ${domainDir}/qa-report.md for full details.
+
+- Are the critical findings legitimate? QA agents sometimes over-flag.
+- If critical findings were verified by the adversarial check, they are real.
+- If overall score is 7+/10 with no verified critical issues, ADVANCE.
+- If there are verified critical issues (wrong prereq order, fake URLs, missing foundational concepts), REDO is mandatory.
+- Your REDO feedback should translate QA findings into specific build instructions, not just repeat the QA agent's words.`,
+
+  schedule: `## Evaluation Criteria: Schedule
+Read workspace/tutor/progress.json to see the applied schedule.
+
+- Are delivery times reasonable for ${timezone}? (not 3am)
+- Is pacing appropriate for ${level} level?
+- Are review days placed after difficulty spikes?
+- Is estimated completion realistic for the lesson count?`,
+}
+
+// ── Tutor judge helper ────────────────────────────────────────
+
+async function tutorJudge(step, stepOutput, extra) {
+  const iteration = extra?.iteration || null
+  const maxIterations = extra?.max || null
+  const isLastIteration = iteration && maxIterations && iteration >= maxIterations
+
+  const prompt = `You are the Tutor — the quality controller for OpenTutor's curriculum generation pipeline for a course on "${topic}" at ${level} level.
+
+You carry accumulated knowledge across every judgment you make. Your context below represents everything you have decided so far. Use it to make sharper decisions — you know what gaps existed, what was enriched, where things were thin.
+
+## Decision Options
+- ADVANCE — Quality is sufficient for this student's learning. Move forward.
+- RESEARCH — You need more depth on a specific subtopic before this step's output can be adequate. Be precise: "Sinkhorn convergence rate analysis" not "more research." This triggers a targeted search for papers and resources on that exact subtopic.
+- REDO — This step's output has fixable problems. Provide specific, actionable feedback that a rebuild agent can act on without guessing. Cite specific lessons, sections, or files.
+- ESCALATE — You genuinely cannot proceed without human judgment. This is rare — use it for fundamental questions about scope, level, or approach.
+
+## Decision Principles
+1. Perfect is the enemy of good. A curriculum that ships is better than one endlessly refined.
+2. Focus on pedagogical impact. Would this issue actually harm the student's learning? If not, ADVANCE.
+3. RESEARCH is for genuine knowledge gaps that make lessons thin or inaccurate, not stylistic preferences.
+4. REDO feedback must name specific items: "Lessons 12-15 need X" not "some lessons need improvement."
+${isLastIteration ? '5. THIS IS THE FINAL ALLOWED ITERATION. You MUST choose ADVANCE unless there are critical pedagogical errors (wrong prerequisite ordering, missing foundational concepts, dangerously incorrect content). Cosmetic issues and minor gaps are acceptable.' : ''}
+
+## Your Accumulated Context
+${tutorMemory.length > 0
+    ? tutorMemory.map((m, i) => `${i + 1}. ${m}`).join('\n')
+    : '(This is your first judgment. No prior context.)'}
+
+${STEP_CRITERIA[step] || ''}
+
+## Step Output Summary
+${typeof stepOutput === 'string' ? stepOutput : JSON.stringify(stepOutput, null, 2)}
+
+${iteration ? `\nThis is attempt ${iteration} of ${maxIterations}.` : ''}
+${researchRounds > 0 ? `\nTargeted research rounds used: ${researchRounds}/${CAPS.targetedResearch}` : ''}`
+
+  const decision = await agent(prompt, {
+    label: `tutor:${step}${iteration ? ':' + iteration : ''}`,
+    phase: step === 'survey' || step === 'survey-enriched' ? 'Survey' : step === 'build' ? 'Build' : step === 'qa' ? 'QA' : step === 'schedule' ? 'Schedule' : 'Survey',
+    schema: TUTOR_DECISION_SCHEMA,
+  })
+
+  if (decision?.context_update) {
+    tutorMemory.push(`[${step}] ${decision.context_update}`)
+  }
+
+  log(`Tutor (${step}): ${decision?.decision || 'unknown'} (confidence: ${decision?.confidence || '?'}/10) — ${decision?.quality_snapshot || ''}`)
+
+  return decision || { decision: 'ADVANCE', confidence: 5, reasoning: 'No response from tutor', context_update: 'Tutor did not respond, defaulting to ADVANCE', quality_snapshot: 'unknown' }
+}
+
+// ── ESCALATE handler ──────────────────────────────────────────
+
+async function handleEscalate(decision) {
+  if (decision?.decision !== 'ESCALATE') return
+
+  await agent(
+    `Write a file to ${domainDir}/escalation.md with the following content:
+
+# Escalation: ${topic}
+
+## Question for Human
+${decision.escalation_question || 'The tutor needs human guidance to proceed.'}
+
+## Tutor Reasoning
+${decision.reasoning || 'No reasoning provided.'}
+
+## Context So Far
+${tutorMemory.map((m, i) => (i + 1) + '. ' + m).join('\n')}
+
+## How to Resume
+Re-run the pipeline with:
+args: {topic: "${topic}", level: "${level}", humanGuidance: "your answer here"}`,
+    { label: 'escalate:write', phase: 'Survey' }
+  )
+
+  throw new Error(`ESCALATE: ${decision.escalation_question || 'Tutor needs human guidance'}. See ${domainDir}/escalation.md`)
+}
+
+// ══════════════════════════════════════════════════════════════
+// PIPELINE
+// ══════════════════════════════════════════════════════════════
+
+// ── Phase 1: Survey Research ──────────────────────────────────
+
+phase('Survey')
+log(`Starting tutor-controlled pipeline for "${topic}" (${level})`)
+
+const surveyResult = await workflow('research', { topic, mode: 'survey' })
+log(`Survey done: coverage ${surveyResult?.coverage || '?'}/10`)
+
+let decision = await tutorJudge('survey', surveyResult)
+
+while (decision.decision === 'RESEARCH' && researchRounds < CAPS.targetedResearch) {
+  log(`Tutor requests targeted research: "${decision.research_query}"`)
+  await workflow('research', { topic, mode: 'targeted', query: decision.research_query })
+  researchRounds++
+  decision = await tutorJudge('survey-enriched', { enrichedWith: decision.research_query, roundsUsed: researchRounds, roundsMax: CAPS.targetedResearch })
+}
+
+if (decision.decision === 'RESEARCH' && researchRounds >= CAPS.targetedResearch) {
+  tutorMemory.push(`[cap-hit] Research cap reached (${CAPS.targetedResearch} rounds). Proceeding with available research.`)
+  log(`Research cap reached (${CAPS.targetedResearch} rounds). Advancing.`)
+}
+
+await handleEscalate(decision)
+
+// ── Phase 2: Audience Assessment ──────────────────────────────
+
+phase('Audience')
+log('Tutor assessing target audience')
+
+const AUDIENCE_SCHEMA = {
+  type: 'object',
+  properties: {
+    audience_type: { type: 'string' },
+    goal: { type: 'string' },
+    background: { type: 'string' },
+    tone: { type: 'string' },
+    depth: { type: 'string' },
+    time_commitment: { type: 'string' },
+    summary: { type: 'string' },
+  },
+  required: ['audience_type', 'goal', 'depth', 'summary'],
+}
+
+const audience = await agent(
+  `You are the Tutor for OpenTutor. Based on the research and context available, define the target audience profile for a course on "${topic}" at ${level} level.
+
+Read:
+- ${domainDir}/research.md — to understand the field's scope and available resources
+- workspace/USER.md — for any existing student profile
+- skills/tutor/references/teaching-method.md — for the teaching methodology
+
+## Your Accumulated Context
+${tutorMemory.map((m, i) => (i + 1) + '. ' + m).join('\n')}
+
+${humanGuidance ? '## Human Guidance\n' + humanGuidance : ''}
+
+Determine:
+
+1. **audience_type** — Who is this for? (e.g., "graduate students in applied math", "software engineers exploring ML theory", "curious adults with calculus background")
+2. **goal** — What is the learning goal? (e.g., "preparation for research", "practical application in ML pipelines", "intellectual enrichment", "exam prep")
+3. **background** — What prerequisites can we assume? Be specific about math/CS/domain knowledge.
+4. **tone** — What teaching tone fits this audience? (e.g., "rigorous but accessible", "hands-on and example-driven", "conversational with formal foundations")
+5. **depth** — How deep should the course go? (e.g., "intuition + key proofs", "full formal treatment", "applied recipes with theoretical grounding")
+6. **time_commitment** — How much time per lesson? (e.g., "3-5 min read + 10 min exercises", "15-20 min deep study")
+7. **summary** — A 2-3 sentence profile that the curriculum builder can use as a north star.
+
+Report as JSON.`,
+  { label: 'audience', phase: 'Audience', schema: AUDIENCE_SCHEMA }
+)
+
+tutorMemory.push(`[audience] ${audience?.summary || 'Audience assessment completed.'}`)
+log(`Audience: ${audience?.audience_type || 'unknown'} — ${audience?.goal || 'unknown goal'}`)
+
+// ── Phase 3: Build Curriculum ─────────────────────────────────
 
 phase('Build')
 
-const buildResult = await workflow('curriculum-build', { topic, level })
-log(`Build done: ${buildResult?.gate || 'unknown'} gate verdict`)
+let buildFeedback = null
+for (let attempt = 1; attempt <= CAPS.buildRedos + 1; attempt++) {
+  const buildMode = buildFeedback ? 'patch' : 'full'
+  const buildResult = await workflow('curriculum-build', {
+    topic,
+    level,
+    mode: buildMode,
+    feedback: buildFeedback,
+    audience: audience?.summary,
+  })
 
-// ── Step 3: Schedule ──────────────────────────────────────────
+  log(`Build attempt ${attempt}: gate=${buildResult?.gate || '?'}, mode=${buildMode}`)
 
-phase('Schedule')
+  decision = await tutorJudge('build', buildResult, { iteration: attempt, max: CAPS.buildRedos + 1 })
 
-const scheduleResult = await workflow('schedule', { topic, timezone })
-log(`Schedule done: ${scheduleResult?.schedule?.pacing || '?'} pacing`)
+  if (decision.decision === 'ADVANCE') break
 
-// ── Step 4: QA ────────────────────────────────────────────────
+  await handleEscalate(decision)
+
+  if (decision.decision === 'RESEARCH' && researchRounds < CAPS.targetedResearch) {
+    log(`Tutor requests targeted research before rebuild: "${decision.research_query}"`)
+    await workflow('research', { topic, mode: 'targeted', query: decision.research_query })
+    researchRounds++
+  }
+
+  buildFeedback = decision.redo_feedback || 'Improve overall quality based on tutor feedback.'
+}
+
+// ── Phase 4: QA ───────────────────────────────────────────────
 
 phase('QA')
 
-const qaResult = await workflow('curriculum-qa', { topic })
-log(`QA done: ${qaResult?.verdict || 'UNKNOWN'} (${qaResult?.score || '?'}/10)`)
+for (let cycle = 1; cycle <= CAPS.qaCycles + 1; cycle++) {
+  const qaResult = await workflow('curriculum-qa', { topic })
 
-// ── Step 5: Register ──────────────────────────────────────────
+  log(`QA cycle ${cycle}: verdict=${qaResult?.verdict || '?'}, score=${qaResult?.score || '?'}/10`)
+
+  decision = await tutorJudge('qa', qaResult, { iteration: cycle, max: CAPS.qaCycles + 1 })
+
+  if (decision.decision === 'ADVANCE') break
+
+  await handleEscalate(decision)
+
+  if (decision.decision === 'RESEARCH' && researchRounds < CAPS.targetedResearch) {
+    log(`Tutor requests targeted research to fix QA issues: "${decision.research_query}"`)
+    await workflow('research', { topic, mode: 'targeted', query: decision.research_query })
+    researchRounds++
+  }
+
+  if (decision.decision === 'REDO' || decision.decision === 'RESEARCH') {
+    log(`Rebuilding (patch) with QA feedback before re-running QA`)
+    await workflow('curriculum-build', {
+      topic,
+      level,
+      mode: 'patch',
+      feedback: decision.redo_feedback || 'Address QA findings.',
+      audience: audience?.summary,
+    })
+  }
+}
+
+// ── Phase 5: Schedule ─────────────────────────────────────────
+
+phase('Schedule')
+
+let schedFeedback = null
+for (let attempt = 1; attempt <= CAPS.scheduleRedos + 1; attempt++) {
+  const schedResult = await workflow('schedule', { topic, timezone, feedback: schedFeedback })
+
+  log(`Schedule attempt ${attempt}: pacing=${schedResult?.schedule?.pacing || '?'}`)
+
+  decision = await tutorJudge('schedule', schedResult, { iteration: attempt, max: CAPS.scheduleRedos + 1 })
+
+  if (decision.decision === 'ADVANCE') break
+
+  await handleEscalate(decision)
+  schedFeedback = decision.redo_feedback
+}
+
+// ── Phase 6: Register ─────────────────────────────────────────
 
 phase('Register')
-
-if (qaResult?.verdict === 'FAIL') {
-  log(`WARNING: QA failed with ${qaResult?.criticalIssues || '?'} critical issues. Topic registered but curriculum needs fixes.`)
-}
 
 await agent(
   `Read workspace/tutor/progress.json and ensure:
@@ -70,14 +370,14 @@ Then read ${domainDir}/curriculum.json and report:
   { label: 'register', phase: 'Register' }
 )
 
-log(`Pipeline complete for "${topic}"`)
+log(`Pipeline complete for "${topic}" — ${tutorMemory.length} tutor judgments, ${researchRounds} targeted research rounds`)
 
 return {
   topic,
   slug,
   level,
-  research: { coverage: researchResult?.coverage },
-  build: { gate: buildResult?.gate },
-  schedule: { pacing: scheduleResult?.schedule?.pacing },
-  qa: { verdict: qaResult?.verdict, score: qaResult?.score },
+  audience: audience?.summary,
+  tutorJudgments: tutorMemory.length,
+  researchRounds,
+  finalMemory: tutorMemory,
 }

--- a/.claude/workflows/research.js
+++ b/.claude/workflows/research.js
@@ -1,21 +1,116 @@
 export const meta = {
   name: 'research',
-  description: 'Parallel academic research for a topic — arxiv, Semantic Scholar, OpenAlex, Wikipedia, web syllabi',
-  whenToUse: 'When adding a new topic or refreshing research for an existing domain. Usage: run with args {topic: "optimal transport"}',
+  description: 'Academic research for a topic — broad survey or targeted deep-dive on a specific subtopic',
+  whenToUse: 'When adding a new topic or filling research gaps. Usage: run with args {topic: "optimal transport"} for survey, or {topic: "optimal transport", mode: "targeted", query: "Sinkhorn regularization"} for targeted',
   phases: [
-    { title: 'Gather', detail: 'Fan out 5 research agents across academic APIs and web sources' },
-    { title: 'Gate', detail: 'CEO-style quality gate reviews research coverage and gaps' },
-    { title: 'Synthesize', detail: 'Merge, deduplicate, and write structured research document' },
+    { title: 'Gather', detail: 'Fan out research agents across academic APIs and web sources' },
+    { title: 'Gate', detail: 'Quality gate reviews research coverage and gaps (survey only)' },
+    { title: 'Synthesize', detail: 'Merge and write structured research document' },
   ],
 }
 
 const topic = args?.topic
 if (!topic) throw new Error('Missing args.topic — pass {topic: "your topic"}')
 
+const mode = args?.mode || 'survey'
 const slug = topic.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 const domainDir = `skills/tutor/domains/${slug}`
 
-// ── Phase 1: Gather — parallel research fork ──────────────────
+// ══════════════════════════════════════════════════════════════
+// TARGETED MODE — focused research on a specific subtopic
+// ══════════════════════════════════════════════════════════════
+
+if (mode === 'targeted') {
+  const query = args?.query
+  if (!query) throw new Error('Targeted mode requires args.query — pass {topic: "...", mode: "targeted", query: "specific subtopic"}')
+
+  phase('Gather')
+  log(`Targeted research: "${query}" within "${topic}"`)
+
+  const results = await parallel([
+    () => agent(
+      `You are a research agent. Search the web for academic papers specifically about "${query}" in the context of "${topic}".
+
+Find the 5-8 most relevant papers. For each paper report:
+- title
+- authors
+- year
+- one-sentence summary of contribution
+- URL (arxiv, DOI, or Semantic Scholar)
+
+Focus narrowly on "${query}" — not the broader field. Only include papers you can verify exist.
+Write as structured markdown.`,
+      { label: 'targeted:academic', phase: 'Gather' }
+    ),
+    () => agent(
+      `You are a research agent. Search the web for practical educational resources specifically about "${query}" in the context of "${topic}".
+
+Find resources in these categories:
+1. **Course modules/lectures** — specific lectures or chapters covering "${query}" (with URLs)
+2. **Tutorials/blog posts** — particularly good explanations of "${query}" (with URLs)
+3. **Code/tools** — repos, notebooks, or interactive demos for "${query}" (with URLs)
+4. **Videos** — specific talks or video explanations (with URLs)
+
+Focus narrowly on "${query}". Only include resources you can confirm exist with real URLs.
+Write as structured markdown.`,
+      { label: 'targeted:practical', phase: 'Gather' }
+    ),
+  ])
+
+  phase('Synthesize')
+
+  const synthesis = await agent(
+    `You are a research synthesizer. Merge the following targeted research on "${query}" (within "${topic}") into a structured markdown section.
+
+## Academic Papers
+${results[0] || '(no results)'}
+
+## Practical Resources
+${results[1] || '(no results)'}
+
+---
+
+Write a focused research section with this exact structure:
+
+## Targeted Research: ${query}
+_Added: (today's date)_
+
+### Key Papers
+Deduplicated list of papers. For each:
+- **Title** (Year) — Authors. One-line summary. URL
+
+### Educational Resources
+Organized by type (courses, tutorials, code, videos).
+
+### Implications for Curriculum
+2-3 sentences: what concepts from "${query}" should a course on "${topic}" cover? What's the right depth for a student?
+
+Rules:
+- Only include resources with real, verifiable URLs
+- Be concise — this supplements existing research, not replaces it`,
+    { label: 'synthesize', phase: 'Synthesize' }
+  )
+
+  await agent(
+    `Read the file ${domainDir}/research.md (if it exists).
+
+APPEND the following section at the end of the file. Do NOT modify any existing content.
+If the file does not exist, create it with just this content.
+
+${synthesis}`,
+    { label: 'append', phase: 'Synthesize' }
+  )
+
+  const paperCount = (results[0] || '').split('\n').filter(l => l.match(/^\s*-\s*\*\*/)).length
+  const resourceCount = (results[1] || '').split('\n').filter(l => l.match(/^\s*-\s*\*\*/)).length
+
+  log(`Targeted research on "${query}" appended to ${domainDir}/research.md`)
+  return { topic, slug, mode: 'targeted', query, paperCount, resourceCount }
+}
+
+// ══════════════════════════════════════════════════════════════
+// SURVEY MODE — broad multi-source research (default)
+// ══════════════════════════════════════════════════════════════
 
 phase('Gather')
 log(`Researching "${topic}" across 5 sources`)
@@ -222,7 +317,6 @@ Rules:
 
 const synthesis = await agent(synthesisPrompt, { label: 'synthesize', phase: 'Synthesize' })
 
-// Write to file
 const writePrompt = `Create the directory ${domainDir} if it doesn't exist, then write the following research document to ${domainDir}/research.md
 
 ${synthesis}`

--- a/.claude/workflows/schedule.js
+++ b/.claude/workflows/schedule.js
@@ -15,6 +15,7 @@ if (!topic) throw new Error('Missing args.topic — pass {topic: "optimal transp
 
 const timezone = args?.timezone || 'America/New_York'
 const timesPerDay = args?.timesPerDay || 3
+const feedback = args?.feedback || null
 const slug = topic.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 const domainDir = `skills/tutor/domains/${slug}`
 
@@ -76,6 +77,7 @@ phase('Design')
 
 const schedule = await agent(
   `You are a learning schedule optimizer. Design an optimal lesson delivery schedule for "${topic}".
+${feedback ? `\n## Previous Attempt Feedback\nThe previous schedule had these issues — address them in your design:\n${feedback}\n` : ''}
 
 ## Curriculum Analysis
 ${JSON.stringify(analysis, null, 2)}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,11 +54,18 @@ opentutor/
 
 ## How domain generation works
 
-1. Student picks a topic during onboarding or via "add topic: X"
-2. Tutor researches the topic (web search, syllabi, textbooks)
-3. Tutor generates `domains/<topic-slug>/` with four files following `templates/domain-template.md`
-4. Tutor registers the topic in `workspace/tutor/progress.json`
-5. When delivering lessons, tutor loads the domain's data + its own pedagogy references
+Domain generation uses a **tutor-controlled pipeline** (`.claude/workflows/new-topic.js`). A tutor agent judges every step and decides: ADVANCE, RESEARCH (targeted deep-dive), REDO (with feedback), or ESCALATE (ask human).
+
+1. **Survey research** — broad multi-source search (arxiv, Semantic Scholar, OpenAlex, Wikipedia, educational). Tutor may request up to 3 targeted research rounds on specific subtopics.
+2. **Audience assessment** — tutor profiles the target learner (audience type, goal, background, tone, depth)
+3. **Build curriculum** — 4 parallel design agents generate domain files. Tutor judges; may trigger targeted research or a rebuild.
+4. **QA** — 5 adversarial dimension checkers + verification. Tutor judges; may trigger patch rebuild + re-QA.
+5. **Schedule** — difficulty analysis + pacing design. Tutor judges.
+6. **Register** — adds topic to `workspace/tutor/progress.json`
+
+Research is **demand-driven**: the tutor can request targeted research at any step, not just during the research phase. Patch mode rebuilds only the parts that need fixing (~5 agents vs 10 for full rebuild).
+
+See `docs/curriculum-generation.md` for the full workflow documentation.
 
 ## Adding or editing skills
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
 
 **:books: Research-Grounded Curricula** — Generates 20-30 lesson curricula sourced from arxiv, Semantic Scholar, OpenAlex, and Wikipedia
 
+**:robot: Tutor-Controlled Pipeline** — A tutor agent judges every step (research, build, QA, schedule) and decides where more work is needed — with demand-driven targeted research
+
 **:repeat: Spaced Repetition** — Built-in flashcard system with SM-2 scheduling to reinforce concepts at optimal intervals
 
 **:chart_with_upwards_trend: Adaptive Difficulty** — Adjusts lesson difficulty based on quiz performance and engagement patterns
 
 **:electric_plug: Multi-Platform** — Works with Claude Code, Cursor, Gemini CLI, OpenCode, OpenClaw, NanoClaw, and any Agent Skills-compatible client
-
-**:zap: Two-Phase Generation** — Instant mini-wiki intro (Phase A) while full curriculum researches in background (Phase B, 30-90s)
 
 **:pencil2: Interactive Exercises** — Inline buttons (A/B/C/D), quiz polls, hints, skip options, and open-ended practice
 
@@ -102,15 +102,41 @@ OpenTutor includes a self-contained Telegram bot. No external gateway needed —
 
 ## How It Works
 
-### Curriculum Generation (Two-Phase)
+### Curriculum Generation (Tutor-Controlled Pipeline)
 
-1. **Phase A (instant)** — sends a mini-wiki intro grounded in Wikipedia + a suggested video/article to engage with immediately
-2. **Phase B (background, 30-90s)** — researches the topic across arxiv, Semantic Scholar, OpenAlex, and Wikipedia in parallel, then synthesizes a full 20-30 lesson curriculum with verified resources
+A **tutor agent** controls the entire pipeline, judging each step and deciding where more work is needed:
+
+```
+Survey Research (broad)
+  → Tutor judges → may request targeted deep-dives
+Audience Assessment
+  → Tutor profiles the target learner (audience, goal, depth, tone)
+Build Curriculum
+  → Tutor judges → may request more research or targeted fixes
+QA (adversarial, 5 dimensions)
+  → Tutor judges → may trigger patch rebuild + re-QA
+Schedule
+  → Tutor judges → may adjust pacing
+Register
+```
+
+The tutor can make four decisions at each step:
+- **ADVANCE** — quality sufficient, move forward
+- **RESEARCH** — "I need more depth on X" (triggers targeted search)
+- **REDO** — redo this step with specific feedback
+- **ESCALATE** — ask the human for guidance
+
+Research is **demand-driven**: a broad survey maps the field upfront, then targeted deep-dives happen whenever the tutor identifies gaps — during build, after QA, wherever needed.
+
+**Phase A (instant)** — sends a mini-wiki intro grounded in Wikipedia + a suggested video/article while the pipeline runs in background.
 
 ### Architecture
 
 ```
 User -> Telegram -> Router -> [Commands, Lessons, Quiz, Chat, Onboarding] -> Claude -> Research APIs
+                                                                                ↕
+                                                                          Tutor Pipeline
+                                                                    (survey → build → QA → schedule)
 ```
 
 ### Workspace Layout

--- a/docs/curriculum-generation.md
+++ b/docs/curriculum-generation.md
@@ -4,7 +4,9 @@ How OpenTutor builds a personalized curriculum when a student picks a topic.
 
 ## Overview
 
-Curriculum generation is a **two-phase process**. Phase A gives the student something useful immediately (an intro to the field + a resource to engage with). Phase B runs research in the background and produces the full syllabus. The student never waits for research — they're reading or watching an intro while it happens.
+Curriculum generation uses a **tutor-controlled pipeline**. A tutor agent judges every step and decides where more work is needed — advancing, requesting targeted research, redoing a step with feedback, or escalating to a human. Research is demand-driven: a broad survey maps the field, then targeted deep-dives happen wherever the tutor identifies gaps.
+
+Phase A gives the student something useful immediately. The tutor pipeline runs in the background.
 
 ```
 Student picks topic
@@ -15,164 +17,165 @@ Student picks topic
   │   ├── Suggest intro video/article to watch now
   │   └── "Building your curriculum..."
   │
-  ├── Phase B (background, 30-90s)
-  │   ├── Research pipeline (parallel)
-  │   │   ├── arxiv → papers, surveys, preprints
-  │   │   ├── Semantic Scholar → highly cited papers, citation graph
-  │   │   ├── OpenAlex → academic topics, landmark works
-  │   │   └── Wikipedia → concept overview, prerequisite structure
-  │   ├── Claude + web search → syllabi, courses, textbooks, videos
-  │   ├── Synthesize into full 20-30 lesson curriculum
-  │   └── Save domain files (curriculum.json, research.md, etc.)
-  │
-  └── Notification
-      └── "📚 Your curriculum is ready! 24 lessons across 6 modules. /next for lesson 1"
+  └── Tutor Pipeline (background)
+      │
+      ├── Survey Research
+      │   ├── 5 parallel agents (arxiv, Semantic Scholar, OpenAlex, Wikipedia, educational)
+      │   ├── Quality gate (coverage score, gap detection)
+      │   ├── Synthesize into research.md
+      │   └── Tutor judges → may request targeted deep-dives
+      │
+      ├── Audience Assessment
+      │   └── Tutor profiles: audience type, goal, background, tone, depth
+      │
+      ├── Build Curriculum
+      │   ├── 4 parallel design agents (structure, concept map, teaching notes, resources)
+      │   ├── Pedagogical quality gate
+      │   ├── Assemble domain files
+      │   └── Tutor judges → may RESEARCH or REDO
+      │
+      ├── QA (adversarial)
+      │   ├── 5 dimension checkers (sequencing, resources, coverage, pedagogy, schema)
+      │   ├── Adversarial verification of critical findings
+      │   ├── Verdict synthesis
+      │   └── Tutor judges → may trigger patch rebuild + re-QA
+      │
+      ├── Schedule
+      │   ├── Difficulty analysis → pacing design → gate → apply
+      │   └── Tutor judges → may adjust
+      │
+      └── Register
+          └── Add topic to progress.json
 ```
+
+## The Tutor Agent
+
+The tutor is a **loop controller** that evaluates the output of every step. At each judgment point, it can:
+
+| Decision | What happens |
+|----------|-------------|
+| **ADVANCE** | Quality sufficient, move to next step |
+| **RESEARCH** | "I need more depth on X" — triggers targeted search for a specific subtopic |
+| **REDO** | Redo this step with specific, actionable feedback |
+| **ESCALATE** | Cannot proceed without human judgment (writes escalation.md, halts pipeline) |
+
+The tutor carries **accumulated context** across all judgments via a memory array. Each judgment's `context_update` gets appended, so later decisions are informed by everything that came before — what gaps existed at survey, what targeted research added, where the build was weak.
+
+### Tutor Decision Principles
+
+1. Perfect is the enemy of good. A curriculum that ships is better than one endlessly refined.
+2. Focus on pedagogical impact. Would this issue actually harm the student's learning? If not, ADVANCE.
+3. On the final allowed iteration, ADVANCE unless there are critical pedagogical errors.
+4. RESEARCH is for genuine knowledge gaps, not stylistic preferences.
+5. REDO feedback must name specific items: "Lessons 12-15 need X" not "some lessons need improvement."
+
+### Iteration Caps
+
+| Cap | Value | Prevents |
+|-----|-------|----------|
+| Targeted research (global) | 3 rounds | Unbounded research loops |
+| Build redos | 2 | Endless rebuilds |
+| Schedule redos | 1 | Over-tuning schedule |
+| QA-rebuild cycles | 2 | Infinite QA loops |
 
 ## Phase A — Welcome & Intro
 
-**Goal:** Give the student something genuinely useful *right now* while research runs.
+**Goal:** Give the student something genuinely useful *right now* while the tutor pipeline runs.
 
 **Triggered by:** `/add <topic>` or topic selection during onboarding.
 
 **What happens:**
 
-1. **Quick Wikipedia lookup** — fetch the topic summary via Wikipedia REST API. This gives a 1-2 sentence description of the field.
-
-2. **Claude generates a mini-wiki intro** — 2-3 sentences about the field: what it is, why it matters, who the key people are. Grounded in the Wikipedia data, not hallucinated.
-
-3. **Suggest an intro resource** — one high-quality entry point for the student to engage with immediately:
-   - A well-known introductory video (e.g., 3Blue1Brown, Veritasium, Khan Academy)
-   - A landmark blog post or article
-   - A Wikipedia deep-read link
-   - The intro chapter of a canonical textbook (if freely available)
-
-   The resource should be something the student can start watching/reading in under 30 seconds. Claude picks based on the topic and student level.
-
-4. **"Building your curriculum..."** — tell the student research is happening, they'll be notified when it's ready.
+1. **Quick Wikipedia lookup** — fetch the topic summary via Wikipedia REST API.
+2. **Claude generates a mini-wiki intro** — 2-3 sentences about the field: what it is, why it matters, who the key people are.
+3. **Suggest an intro resource** — one high-quality entry point the student can start in under 30 seconds.
+4. **"Building your curriculum..."** — tell the student research is happening.
 
 **What is NOT in Phase A:**
-- No lesson delivery. No scaffold lessons. No hallucinated lesson titles.
-- No fake resource URLs. If Claude can't confidently name a real resource, it says "I'll find the best resources during research."
+- No lesson delivery. No hallucinated lesson titles.
+- No fake resource URLs.
 
-**Example output (Telegram):**
+## Research — Survey & Targeted Modes
 
-```
-📖 Optimal Transport
+Research supports two modes, controlled by the tutor:
 
-The math of moving things efficiently — from Monge's 18th-century 
-earth-moving problem to modern machine learning. It connects 
-probability, geometry, and optimization in surprisingly deep ways.
+### Survey Mode (default, runs once at start)
 
-Key people: Gaspard Monge, Leonid Kantorovich (Nobel '75), 
-Cédric Villani (Fields '10), Marco Cuturi (Sinkhorn).
-
-🎬 Start here while I build your curriculum:
-"Optimal Transport — aass primer" by Gabriel Peyré
-https://optimaltransport.github.io/
-
-Building your full curriculum now — I'll let you know when it's ready.
-```
-
-## Phase B — Research & Synthesis
-
-**Goal:** Build a complete, research-grounded curriculum with verified resources.
-
-**Runs:** In the background, non-blocking. Student can interact with the bot while this runs.
-
-### Step 1: Research Pipeline
-
-Four academic APIs are queried **in parallel**:
+Five parallel agents search different academic sources:
 
 | Source | What it provides | Best for |
 |---|---|---|
 | **arxiv** | Papers, preprints, survey articles | Research-level topics, cutting-edge material |
 | **Semantic Scholar** | Highly cited papers, citation counts, TLDRs | Finding seminal/canonical works |
 | **OpenAlex** | Academic topics, landmark works, related fields | Broad academic landscape, interdisciplinary links |
-| **Wikipedia** | Concept overview, prerequisite structure | Grounding, prerequisite detection, accessible summaries |
+| **Wikipedia** | Concept overview, prerequisite structure | Grounding, accessible summaries |
+| **Educational** | Courses, textbooks, videos, tools, key people | Teaching resources |
 
-All APIs are free, no keys needed. Rate limiting is handled gracefully (Semantic Scholar returns 429s under load — the pipeline continues without it).
+A quality gate evaluates coverage (1-10 score) and identifies gaps. A synthesizer merges and deduplicates results into `research.md`.
 
-**Timeouts:** Each API call has a 15-second timeout. If one fails, the others still contribute.
+### Targeted Mode (on-demand, triggered by tutor)
 
-### Step 2: Claude + Web Search
+When the tutor identifies a gap ("I need more on Sinkhorn regularization"), targeted mode runs a lean 3-agent pipeline:
 
-After the API results are gathered, Claude receives them as context and is given access to the **Anthropic built-in web search tool** (`web_search_20250305`, up to 5 searches).
+1. **Academic deep-dive** — papers specifically on the subtopic
+2. **Practical resources** — courses, tutorials, code, tools for the subtopic
+3. **Synthesizer** — appends a `## Targeted Research: {subtopic}` section to the existing `research.md`
 
-Claude uses web search to fill gaps the APIs missed:
-- University course syllabi and outlines
-- Specific textbook chapter structures
-- Video playlists and tutorial series
-- Interactive tools (Desmos, GeoGebra, Observable notebooks)
+No quality gate in targeted mode — the tutor judges whether the gap was filled.
 
-### Step 3: Curriculum Synthesis
+## Audience Assessment
 
-Claude synthesizes all research into a complete domain:
+Before building the curriculum, the tutor defines the target audience profile:
 
-**`curriculum.json`** — 20-30 lessons organized into modules:
-```json
-{
-  "topic": "Optimal Transport",
-  "slug": "optimal-transport",
-  "created": "2026-04-14",
-  "student_level": "advanced",
-  "prerequisites": ["measure theory basics", "linear algebra", "probability"],
-  "exit_criteria": [
-    "Explain Monge vs Kantorovich formulation",
-    "Implement Sinkhorn algorithm from scratch",
-    "Read a modern OT paper and understand its contribution"
-  ],
-  "lessons": [
-    {
-      "day": 1,
-      "module": "Foundations",
-      "title": "Why does moving dirt cost money?",
-      "concepts": ["Monge problem", "cost function", "transport map"],
-      "resources": ["https://optimaltransport.github.io/", "Peyré & Cuturi Ch 1"],
-      "status": "pending"
-    }
-  ]
-}
-```
+- **audience_type** — Who is this for? (e.g., "software engineers exploring ML theory")
+- **goal** — Learning goal (e.g., "practical application", "exam prep", "intellectual enrichment")
+- **background** — Prerequisites the curriculum can assume
+- **tone** — Teaching tone (e.g., "rigorous but accessible", "hands-on")
+- **depth** — How deep to go (e.g., "intuition + key proofs", "full formal treatment")
+- **time_commitment** — Time per lesson
 
-**Lesson design principles:**
-- Titles are questions or provocations, not topic labels
-- Each lesson = one core concept, ~3-5 minute read
-- Review days every 5-7 lessons (spaced repetition)
-- Resources are real URLs verified during research
-- Prerequisites flagged if student might be missing background
+This profile flows into the curriculum build as a north star for all design agents.
 
-**`teaching-notes.md`** — domain-specific pedagogy:
-- How to teach this topic at the student's level
-- Common misconceptions and how to correct them
-- Level adjustments (what to emphasize/skip)
-- Rabbit holes (fascinating tangents to drop in at the right moment)
+## Curriculum Build — Full & Patch Modes
 
-**`concept-map.md`** — dependency graph:
-- Core concepts in learning order
-- Dependencies between concepts
-- Bottleneck concepts (if you don't get this, nothing after makes sense)
-- Prerequisite topics from outside the domain
+### Full Mode (first build)
 
-**`research.md`** — raw research results preserved for reference:
-- All papers found (arxiv, Semantic Scholar)
-- Wikipedia summaries
-- OpenAlex topics and related fields
-- Serves as an audit trail for where curriculum resources came from
+Four parallel design agents, each with the research and audience context:
 
-### Step 4: Notification
+1. **Structure** — module organization, lesson sequence, exit criteria
+2. **Concept map** — dependency graph, bottlenecks, misconceptions
+3. **Teaching notes** — pedagogical guidance, difficulty progression, exercises
+4. **Resources** — curated books, videos, tools, code, people
 
-When Phase B completes, the bot sends a message to the student:
+A pedagogical quality gate checks sequencing, coverage, difficulty curve, engagement, and resources. Four parallel writers assemble the domain files.
 
-```
-📚 Your curriculum is ready!
+~10 agents total.
 
-Optimal Transport — 30 lessons across 7 modules
-Based on: Peyré & Cuturi (Computational OT), Villani (Topics in OT), 
-MIT 18.S096, and 10 research papers.
+### Patch Mode (targeted fixes)
 
-Type /next for your first lesson.
-```
+When the tutor or QA identifies specific issues, patch mode does a targeted rebuild:
+
+- 2 parallel patch agents (one for curriculum + concept map, one for resources + teaching notes)
+- Each reads the existing files and applies only the cited fixes
+- Same quality gate checks for regressions
+
+~5-6 agents instead of 10. Unchanged parts stay unchanged, reducing regression risk.
+
+## QA — Adversarial Quality Checks
+
+Five specialist agents check different dimensions in parallel:
+
+| Dimension | Checks |
+|-----------|--------|
+| **Sequencing** | Prerequisite ordering, circular dependencies, review day placement |
+| **Resources** | URL validity, resource existence, level appropriateness |
+| **Coverage** | Concept completeness, orphan concepts, depth balance |
+| **Pedagogy** | Lesson titles, concept density, difficulty spikes, engagement |
+| **Schema** | Required fields, day sequence, status values, JSON validity |
+
+Critical findings get adversarially verified — each verifier is prompted to *refute* the finding. Survivors are confirmed; refuted findings are dropped.
+
+A verdict synthesizer produces a pass/fail report with a prioritized fix plan.
 
 ## Storage
 
@@ -183,30 +186,42 @@ domains/optimal-transport/
 ├── curriculum.json      # Lesson sequence (20-30 lessons)
 ├── concept-map.md       # Concept dependency graph
 ├── teaching-notes.md    # Domain-specific pedagogy
-├── resources.md         # Curated resource list (if generated separately)
-└── research.md          # Raw API results from research pipeline
+├── resources.md         # Curated resource list
+├── research.md          # Synthesized research + targeted research appendices
+├── qa-report.md         # QA findings and verdict
+└── escalation.md        # (only if tutor escalated to human)
 ```
 
-## Enrichment of Existing Curricula
+## ESCALATE & Resume
 
-Topics that were created before the research pipeline can be enriched retroactively:
+When the tutor escalates, the pipeline:
+1. Writes `escalation.md` with the question, reasoning, and accumulated context
+2. Throws an error — the pipeline halts
 
-```javascript
-import { enrichExistingTopic } from './curriculum.js';
-await enrichExistingTopic('optimal-transport', skills);
+To resume, re-run with `humanGuidance` in args:
+```
+args: {topic: "category theory", level: "intermediate", humanGuidance: "your answer here"}
 ```
 
-This runs Phase B on an existing domain. Lesson completion status is preserved — if the student completed lessons 1-5, those stay marked as completed in the enriched curriculum.
+Existing domain files on disk let the pipeline skip completed steps.
+
+## Agent Count Estimates
+
+| Scenario | Agents | Description |
+|----------|--------|-------------|
+| Best case | ~35 | Every step passes first try |
+| Typical | ~60 | 1 targeted research + 1 QA-triggered patch rebuild |
+| Worst case | ~102 | All caps hit |
 
 ## Failure Modes
 
 | Failure | Handling |
 |---|---|
-| All research APIs fail | Phase B logs error, scaffold stays as-is. Student can still learn from Claude's knowledge. |
-| Claude can't parse research into curriculum | Error logged, scaffold preserved. Admin can retry with `/enrich`. |
-| Semantic Scholar rate limited (429) | Skipped gracefully, other 3 APIs continue. |
-| Web search unavailable (CLI backend) | Phase B runs without web search, uses only API research results. |
-| Phase B completes after student already did lesson 1 | Completion status preserved during enrichment. No progress lost. |
+| All research APIs fail | Survey logs error, tutor may ESCALATE or ADVANCE with limited data |
+| QA finds critical issues | Tutor triggers patch rebuild + re-QA (up to 2 cycles) |
+| Tutor can't resolve quality issue | ESCALATE — writes question to escalation.md, halts for human |
+| Research cap exhausted | Tutor forced to ADVANCE with available research |
+| Iteration cap hit | Tutor must ADVANCE unless critical pedagogical errors exist |
 
 ## Configuration
 
@@ -222,11 +237,12 @@ Environment variables in `.env`:
 
 | File | Purpose |
 |---|---|
-| `scripts/bot/curriculum.js` | Two-phase generation orchestration |
-| `scripts/bot/research.js` | Research pipeline (arxiv, Semantic Scholar, OpenAlex, Wikipedia) |
-| `scripts/bot/context.js` | Prompt builders: `buildScaffoldPrompt`, `buildResearchSynthesisPrompt` |
-| `scripts/bot/claude.js` | Claude wrapper with `webSearch` option |
-| `scripts/bot/commands.js` | `/add` command triggers generation |
-| `scripts/bot/onboarding.js` | Onboarding flow triggers generation |
+| `.claude/workflows/new-topic.js` | Tutor-controlled pipeline orchestrator |
+| `.claude/workflows/research.js` | Survey + targeted research modes |
+| `.claude/workflows/curriculum-build.js` | Full + patch curriculum build |
+| `.claude/workflows/curriculum-qa.js` | Adversarial 5-dimension QA |
+| `.claude/workflows/schedule.js` | Difficulty analysis and schedule design |
+| `scripts/bot/curriculum.js` | Phase A (instant intro) + Phase B trigger |
+| `scripts/bot/research.js` | Bot-level research pipeline (API calls) |
 | `skills/tutor/templates/domain-template.md` | Template for domain file structure |
 | `skills/tutor/references/curriculum-format.md` | JSON schema for curriculum files |


### PR DESCRIPTION
## Summary

- **Tutor-controlled pipeline**: rewrites `new-topic.js` from a linear chain to a loop where a tutor agent judges every step (survey, build, QA, schedule) and decides: ADVANCE, RESEARCH, REDO, or ESCALATE
- **Demand-driven research**: broad survey upfront, then targeted deep-dives whenever the tutor identifies gaps — during build, after QA, wherever needed (`research.js` supports `mode: "survey"` and `mode: "targeted"`)
- **Audience assessment**: tutor profiles the target learner (audience type, goal, background, tone, depth) before building the curriculum
- **Patch mode builds**: `curriculum-build.js` supports `mode: "patch"` for targeted fixes (~5 agents vs 10 for full rebuild)
- **Pipeline report**: `pipeline-report.md` generated after each run with full tutor decision log
- **Dry-run mode**: `{dryRun: true}` stops after survey + audience assessment, writes `preview.md`
- **Dashboard**: new `dashboard.js` workflow generates a self-contained HTML progress dashboard (stat cards, progress bars, concept mastery grid, lesson timeline)
- **Multi-topic awareness**: cross-topic overlap scan during build; shared concepts flow into design agents; teaching notes include connections section
- **Docs updated**: README, CLAUDE.md, and `docs/curriculum-generation.md` reflect the new architecture

## Test plan

- [x] All 58 existing tests pass (`vitest run`)
- [x] All 6 workflow files pass JS syntax validation
- [ ] End-to-end: run `new-topic` workflow with a test topic
- [ ] Dry-run: run with `{dryRun: true}` to verify preview output
- [ ] Dashboard: run `dashboard` workflow to verify HTML generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)