### PR TITLE
feat: Socratic lesson delivery with adaptive student model

### DIFF
--- a/lib/core/deliberate-practice.js
+++ b/lib/core/deliberate-practice.js
@@ -1,0 +1,263 @@
+/**
+ * DeliberatePractitioner agent — evaluates whether teaching follows
+ * deliberate practice principles. Runs after each lesson, writes
+ * enforceable directives to practice-feedback.md.
+ *
+ * Directives:
+ *   BLOCK  — do not advance until a concept is retested
+ *   BUMP   — increase difficulty for next lesson
+ *   DROP   — decrease difficulty, add scaffolding
+ *   VARY   — change lesson format (teach-back, real-world, etc.)
+ *   REVISIT — re-test a specific shaky concept
+ *   GOAL   — explicit goal the student must demonstrate
+ */
+
+import { buildStudentModel } from './student-model.js';
+
+const DIRECTIVE_TYPES = ['BLOCK', 'BUMP', 'DROP', 'VARY', 'REVISIT', 'GOAL'];
+
+/**
+ * Run the DeliberatePractitioner after a lesson.
+ * Deterministic evaluation — no LLM call needed.
+ */
+export function evaluatePractice(learningMd, curriculum, userProfile) {
+  const model = buildStudentModel(learningMd, curriculum, userProfile);
+  const directives = [];
+  const observations = [];
+
+  // 1. TARGET WEAKNESSES — are shaky concepts being addressed?
+  if (model.concepts.shaky.length > 0) {
+    const lessonssinceShaky = countLessonsSinceConceptsWereShaky(curriculum, model.concepts.shaky);
+    for (const concept of model.concepts.shaky) {
+      const lessonsSince = lessonssinceShaky[concept] || 0;
+      if (lessonsSince >= 3) {
+        directives.push({
+          type: 'REVISIT',
+          target: concept,
+          reason: `Concept "${concept}" was flagged as shaky ${lessonsSince} lessons ago and hasn't been retested`,
+          priority: 'high',
+        });
+      }
+      if (lessonsSince >= 5) {
+        directives.push({
+          type: 'BLOCK',
+          target: concept,
+          reason: `BLOCK advancement until "${concept}" is retested — ${lessonsSince} lessons without addressing it`,
+          priority: 'critical',
+        });
+      }
+    }
+    if (model.concepts.shaky.length > 2) {
+      observations.push(`${model.concepts.shaky.length} shaky concepts accumulating without review`);
+    }
+  }
+
+  // 2. STRETCH ZONE — is difficulty appropriate?
+  if (model.recentAccuracy > 0.8 && model.difficulty.level < 4) {
+    directives.push({
+      type: 'BUMP',
+      target: `difficulty to ${Math.min(5, model.difficulty.level + 1)}`,
+      reason: `Student accuracy at ${Math.round(model.recentAccuracy * 100)}% — coasting below stretch zone`,
+      priority: 'high',
+    });
+    observations.push('Student is coasting — accuracy too high for current difficulty');
+  }
+
+  if (model.recentAccuracy < 0.3) {
+    directives.push({
+      type: 'DROP',
+      target: `difficulty to ${Math.max(1, model.difficulty.level - 1)}`,
+      reason: `Accuracy at ${Math.round(model.recentAccuracy * 100)}% — frustration zone, need scaffolding`,
+      priority: 'high',
+    });
+    observations.push('Student in frustration zone — too hard');
+  }
+
+  // 3. REPETITION WITH VARIATION — is the format varying?
+  const recentFormats = getRecentLessonFormats(curriculum, 5);
+  const uniqueFormats = new Set(recentFormats);
+  if (recentFormats.length >= 4 && uniqueFormats.size <= 1) {
+    const otherFormats = ['teach-back', 'real-world', 'question', 'resource-drop']
+      .filter((f) => !uniqueFormats.has(f));
+    directives.push({
+      type: 'VARY',
+      target: otherFormats[0] || 'teach-back',
+      reason: `Last ${recentFormats.length} lessons all used "${recentFormats[0]}" format — no variation`,
+      priority: 'medium',
+    });
+    observations.push('Lesson format has been monotonous');
+  }
+
+  // 4. ENGAGEMENT — is the student checked out?
+  if (model.engagement === 'low' || model.engagement === 'declining') {
+    if (!directives.some((d) => d.type === 'VARY')) {
+      directives.push({
+        type: 'VARY',
+        target: 'real-world',
+        reason: 'Engagement is declining — try a real-world application to re-engage',
+        priority: 'high',
+      });
+    }
+    observations.push('Engagement declining — need format change or curiosity hook');
+  }
+
+  // 5. GOALS — ensure next lesson has an explicit, testable goal
+  directives.push({
+    type: 'GOAL',
+    target: 'required',
+    reason: 'Every lesson must open with an explicit goal and close with self-assessment',
+    priority: 'standard',
+  });
+
+  return {
+    model,
+    directives,
+    observations,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * Format practice feedback as markdown for the domain directory.
+ */
+export function formatPracticeFeedback(evaluation, topicName) {
+  const lines = [
+    `# Practice Feedback: ${topicName}`,
+    `Updated: ${evaluation.timestamp}`,
+    '',
+  ];
+
+  if (evaluation.observations.length) {
+    lines.push('## Observations');
+    for (const obs of evaluation.observations) {
+      lines.push(`- ${obs}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## Directives');
+  if (!evaluation.directives.length) {
+    lines.push('No issues — deliberate practice principles are being followed.');
+  } else {
+    const byPriority = { critical: [], high: [], medium: [], standard: [] };
+    for (const d of evaluation.directives) {
+      (byPriority[d.priority] || byPriority.standard).push(d);
+    }
+    for (const [priority, dirs] of Object.entries(byPriority)) {
+      if (!dirs.length) continue;
+      for (const d of dirs) {
+        lines.push(`- **${d.type}** [${priority}]: ${d.target} — ${d.reason}`);
+      }
+    }
+  }
+
+  lines.push('', '## Student Snapshot');
+  lines.push(`- Accuracy: ${Math.round(evaluation.model.recentAccuracy * 100)}% (last 5)`);
+  lines.push(`- Trend: ${evaluation.model.trend}`);
+  lines.push(`- Difficulty: ${evaluation.model.difficulty.level} (${evaluation.model.difficulty.label})`);
+  lines.push(`- Engagement: ${evaluation.model.engagement}`);
+
+  if (evaluation.model.concepts.shaky.length) {
+    lines.push(`- Shaky: ${evaluation.model.concepts.shaky.join(', ')}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Parse directives from practice-feedback.md.
+ * Returns structured directives that lesson delivery can enforce.
+ */
+export function parseDirectives(feedbackMd) {
+  if (!feedbackMd) return [];
+
+  const directives = [];
+  const pattern = /\*\*(BLOCK|BUMP|DROP|VARY|REVISIT|GOAL)\*\*\s*\[(\w+)\]:\s*(.+?)(?:\s*—\s*(.+))?$/gm;
+  let m;
+  while ((m = pattern.exec(feedbackMd)) !== null) {
+    directives.push({
+      type: m[1],
+      priority: m[2],
+      target: m[3].trim(),
+      reason: m[4]?.trim() || '',
+    });
+  }
+
+  return directives;
+}
+
+/**
+ * Apply directives to modify lesson delivery behavior.
+ * Returns an object with enforced constraints.
+ */
+export function applyDirectives(directives) {
+  const constraints = {
+    blocked: false,
+    blockedConcept: null,
+    difficultyOverride: null,
+    formatOverride: null,
+    revisitConcepts: [],
+    requireGoal: false,
+  };
+
+  for (const d of directives) {
+    switch (d.type) {
+      case 'BLOCK':
+        constraints.blocked = true;
+        constraints.blockedConcept = d.target;
+        break;
+      case 'BUMP': {
+        const level = parseInt(d.target.match(/\d/)?.[0]);
+        if (level) constraints.difficultyOverride = level;
+        break;
+      }
+      case 'DROP': {
+        const level = parseInt(d.target.match(/\d/)?.[0]);
+        if (level) constraints.difficultyOverride = level;
+        break;
+      }
+      case 'VARY':
+        constraints.formatOverride = d.target;
+        break;
+      case 'REVISIT':
+        constraints.revisitConcepts.push(d.target);
+        break;
+      case 'GOAL':
+        constraints.requireGoal = true;
+        break;
+    }
+  }
+
+  return constraints;
+}
+
+// ── Helpers ─────────────────────────────────────────────────
+
+function countLessonsSinceConceptsWereShaky(curriculum, shakyConcepts) {
+  if (!curriculum?.lessons) return {};
+
+  const completed = curriculum.lessons.filter((l) => l.status === 'completed');
+  const counts = {};
+
+  for (const concept of shakyConcepts) {
+    let found = false;
+    for (let i = completed.length - 1; i >= 0; i--) {
+      if ((completed[i].concepts || []).includes(concept)) {
+        counts[concept] = completed.length - 1 - i;
+        found = true;
+        break;
+      }
+    }
+    if (!found) counts[concept] = completed.length;
+  }
+
+  return counts;
+}
+
+function getRecentLessonFormats(curriculum, count) {
+  if (!curriculum?.lessons) return [];
+  return curriculum.lessons
+    .filter((l) => l.status === 'completed')
+    .slice(-count)
+    .map((l) => l.type || 'mini-lesson');
+}

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -26,3 +26,4 @@ export {
   buildSocraticResponsePrompt,
 } from './prompts.js';
 export { buildStudentModel, formatStudentModel } from './student-model.js';
+export { evaluatePractice, formatPracticeFeedback, parseDirectives, applyDirectives } from './deliberate-practice.js';

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -22,4 +22,7 @@ export {
   buildDomainFilesPrompt,
   buildCriticPrompt,
   buildTeacherPrompt,
+  buildLessonPlanPrompt,
+  buildSocraticResponsePrompt,
 } from './prompts.js';
+export { buildStudentModel, formatStudentModel } from './student-model.js';

--- a/lib/core/prompts.js
+++ b/lib/core/prompts.js
@@ -285,8 +285,9 @@ Keep your response to 2-4 sentences max, then the challenge.`,
     application: `The student attempted the application challenge. Wrap up:
 - Give specific feedback on their answer (what was right, what could be better)
 - Connect back to the lesson goal
+- Ask them to self-assess: "On a scale of 1-5, how confident do you feel about [goal]?"
 - End with one sentence that hooks into the next lesson topic
-Keep your response to 3-4 sentences. End with encouragement, not a question.`,
+Keep your response to 3-4 sentences plus the self-assessment question.`,
   };
 
   const system = [

--- a/lib/core/prompts.js
+++ b/lib/core/prompts.js
@@ -209,4 +209,106 @@ Adaptation rules:
   return { system, model: 'strong', outputMode: 'student' };
 }
 
+// ── Socratic lesson prompts ─────────────────────────────────
+
+export function buildLessonPlanPrompt(state, skills, lesson, topicSlug, studentModel) {
+  const teacherConfig = state.readDomainFile(topicSlug, 'teacher.md') || '';
+  const teachingNotes = state.readDomainFile(topicSlug, 'teaching-notes.md') || '';
+  const conceptMap = state.readDomainFile(topicSlug, 'concept-map.md') || '';
+  const user = state.readUser();
+
+  const lessonData = JSON.stringify({
+    day: lesson.day || lesson.lesson,
+    title: lesson.title,
+    module: lesson.module,
+    concepts: lesson.concepts,
+    type: lesson.type,
+    difficulty: lesson.difficulty,
+  });
+
+  const system = [
+    `## Lesson Planner
+
+You are designing a single Socratic lesson. You do NOT deliver the lesson — you produce a structured plan that another agent will use to teach conversationally.`,
+    skills.get('teaching-method'),
+    untrustedData('domain-teaching-config', teacherConfig, 4_000),
+    untrustedData('teaching-notes', teachingNotes, 4_000),
+    untrustedData('concept-map', conceptMap, 4_000),
+    untrustedData('student-profile', user, 3_000),
+    untrustedData('student-model', studentModel || '', 2_000),
+    untrustedData('current-lesson', lessonData, 2_000),
+    `## Instructions
+
+Generate a Socratic lesson plan for this concept. The plan will be delivered as a multi-turn conversation where the student answers at each step.
+
+Output as JSON:
+{
+  "goal": "After this lesson, the student should be able to: [specific, testable goal]",
+  "diagnostic": "Opening question to gauge what the student already knows about this concept. Should be answerable in 1-2 sentences. Not multiple choice — open-ended.",
+  "concept": "The core idea in 2-3 sentences. This is delivered AFTER the student answers the diagnostic, tailored to what they revealed.",
+  "followUp": "A Socratic question that pushes the student to apply or extend the concept. Should require thinking, not just recall.",
+  "application": "A real-world scenario or challenge: 'Given X, what would you do?' Should feel concrete and relevant.",
+  "commonMisconceptions": [
+    { "ifStudentSays": "pattern to watch for", "theyProbablyThink": "underlying misconception", "correctWith": "how to address it" }
+  ],
+  "difficulty": ${lesson.difficulty || 3},
+  "adaptations": "How this lesson is adapted based on the student model (e.g., 'more examples because student struggles with abstraction', 'skip basics because accuracy is high')"
+}
+
+Rules:
+- The diagnostic should feel like genuine curiosity, not a test
+- Keep everything SHORT — this is Telegram, not a textbook
+- If the student model says accuracy is high, make the diagnostic harder and skip scaffolding
+- If accuracy is low, make the diagnostic easier and add more scaffolding in the concept
+- Match exercise style to the domain config
+- Do NOT output anything outside the JSON`,
+  ].filter(Boolean).join('\n\n---\n\n');
+
+  return { system, model: 'strong', outputMode: 'json' };
+}
+
+export function buildSocraticResponsePrompt(lessonPlan, studentAnswer, step, user) {
+  const stepInstructions = {
+    diagnostic: `The student just answered your diagnostic question. Assess what they know:
+- If they got it roughly right: acknowledge briefly, then deliver the core concept with a twist they didn't mention
+- If they got it wrong: don't say "wrong" — say "interesting" and use their answer to teach the concept
+- If they said "I don't know": that's fine, teach from scratch with a concrete example
+Then ask the follow-up question from the lesson plan.
+Keep your response to 2-4 sentences max, then the question.`,
+
+    followUp: `The student answered your follow-up question. Push deeper:
+- If they're on track: raise the stakes — connect to a broader implication or surprising consequence
+- If they're struggling: simplify, use an analogy, or break it into a smaller step
+Then present the application challenge from the lesson plan.
+Keep your response to 2-4 sentences max, then the challenge.`,
+
+    application: `The student attempted the application challenge. Wrap up:
+- Give specific feedback on their answer (what was right, what could be better)
+- Connect back to the lesson goal
+- End with one sentence that hooks into the next lesson topic
+Keep your response to 3-4 sentences. End with encouragement, not a question.`,
+  };
+
+  const system = [
+    `## Socratic Tutor
+
+You are mid-conversation with a student. Respond to their answer naturally — warm, concise, and specific to what they said. Never generic.`,
+    untrustedData('lesson-plan', JSON.stringify(lessonPlan), 3_000),
+    untrustedData('student-profile', user || '', 2_000),
+    `## Current Step: ${step}
+
+${stepInstructions[step] || stepInstructions.diagnostic}
+
+Rules:
+- 2-4 sentences for your response, then a question (unless this is the final step)
+- Reference what the student ACTUALLY said — don't ignore their answer
+- Use their misconceptions from the lesson plan if they match
+- Never say "Great question!" or "That's a great answer!" — just teach
+- Telegram format: use <b>, <i> for emphasis. No markdown.
+- Do NOT output anything except what the student should see`,
+  ].filter(Boolean).join('\n\n---\n\n');
+
+  return { system, model: 'cheap', outputMode: 'student' };
+}
+
 export { untrustedData, clip, escapeXml };

--- a/lib/core/student-model.js
+++ b/lib/core/student-model.js
@@ -1,0 +1,188 @@
+/**
+ * Student model — computes adaptive difficulty, accuracy trends,
+ * and engagement signals from learning history.
+ *
+ * Reads learning.md + curriculum progress. Produces a structured
+ * assessment the Teacher uses to calibrate each lesson.
+ */
+
+export function buildStudentModel(learningMd, curriculum, userProfile) {
+  const exercises = parseExerciseHistory(learningMd);
+  const recentAccuracy = computeAccuracy(exercises, 5);
+  const overallAccuracy = computeAccuracy(exercises, exercises.length);
+  const trend = computeTrend(exercises, 5);
+  const difficulty = computeDifficulty(recentAccuracy, trend, curriculum);
+  const engagement = parseEngagement(learningMd);
+  const concepts = classifyConcepts(exercises, curriculum);
+
+  return {
+    recentAccuracy,
+    overallAccuracy,
+    trend,
+    difficulty,
+    engagement,
+    concepts,
+    exerciseCount: exercises.length,
+    recommendations: generateRecommendations(recentAccuracy, trend, engagement, concepts),
+  };
+}
+
+export function formatStudentModel(model) {
+  const lines = [
+    '## Student Model (computed)',
+    '',
+    '## Accuracy',
+    `- **Recent (last 5):** ${Math.round(model.recentAccuracy * 100)}%`,
+    `- **Overall:** ${Math.round(model.overallAccuracy * 100)}% across ${model.exerciseCount} exercises`,
+    `- **Trend:** ${model.trend}`,
+    '',
+    '## Difficulty',
+    `- **Current level:** ${model.difficulty.level} (${model.difficulty.label})`,
+    `- **Adjustment:** ${model.difficulty.adjustment}`,
+    '',
+    '## Engagement',
+    `- **Level:** ${model.engagement}`,
+    '',
+    '## Concepts',
+  ];
+
+  if (model.concepts.solid.length) {
+    lines.push(`- **Solid:** ${model.concepts.solid.join(', ')}`);
+  }
+  if (model.concepts.shaky.length) {
+    lines.push(`- **Shaky (needs reinforcement):** ${model.concepts.shaky.join(', ')}`);
+  }
+
+  if (model.recommendations.length) {
+    lines.push('', '## Recommendations');
+    for (const r of model.recommendations) {
+      lines.push(`- ${r}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ── Parsing ─────────────────────────────────────────────────
+
+function parseExerciseHistory(learningMd) {
+  if (!learningMd) return [];
+
+  const exercises = [];
+  const resultPattern = /\*\*Last exercise:\*\*\s*(correct|incorrect|pending)/gi;
+  let m;
+  while ((m = resultPattern.exec(learningMd)) !== null) {
+    exercises.push({ result: m[1].toLowerCase() });
+  }
+
+  // Also parse from history section if present
+  const historyPattern = /([✓✗])\s/g;
+  while ((m = historyPattern.exec(learningMd)) !== null) {
+    exercises.push({ result: m[1] === '✓' ? 'correct' : 'incorrect' });
+  }
+
+  return exercises;
+}
+
+function parseEngagement(learningMd) {
+  if (!learningMd) return 'unknown';
+
+  if (/engagement.*low/i.test(learningMd)) return 'low';
+  if (/engagement.*high/i.test(learningMd)) return 'high';
+  if (/trending shorter/i.test(learningMd)) return 'declining';
+  return 'steady';
+}
+
+// ── Computation ─────────────────────────────────────────────
+
+function computeAccuracy(exercises, windowSize) {
+  if (!exercises.length) return 0.5;
+
+  const window = exercises.slice(-windowSize);
+  const scored = window.filter((e) => e.result !== 'pending');
+  if (!scored.length) return 0.5;
+
+  const correct = scored.filter((e) => e.result === 'correct').length;
+  return correct / scored.length;
+}
+
+function computeTrend(exercises, windowSize) {
+  if (exercises.length < 4) return 'insufficient data';
+
+  const half = Math.floor(windowSize / 2);
+  const recent = exercises.slice(-half);
+  const earlier = exercises.slice(-(half * 2), -half);
+
+  if (!recent.length || !earlier.length) return 'insufficient data';
+
+  const recentAcc = computeAccuracy(recent, recent.length);
+  const earlierAcc = computeAccuracy(earlier, earlier.length);
+  const delta = recentAcc - earlierAcc;
+
+  if (delta > 0.15) return 'improving';
+  if (delta < -0.15) return 'declining';
+  return 'plateaued';
+}
+
+function computeDifficulty(recentAccuracy, trend, curriculum) {
+  // Find current difficulty from next pending lesson
+  const nextLesson = curriculum?.lessons?.find((l) => l.status === 'pending');
+  const baseDifficulty = nextLesson?.difficulty || 3;
+
+  let level = baseDifficulty;
+  let adjustment = 'none';
+
+  if (recentAccuracy > 0.8 && trend !== 'declining') {
+    level = Math.min(5, baseDifficulty + 1);
+    adjustment = 'bump up — student is breezing through';
+  } else if (recentAccuracy < 0.4) {
+    level = Math.max(1, baseDifficulty - 1);
+    adjustment = 'drop back — student needs more scaffolding';
+  } else if (trend === 'plateaued' && recentAccuracy > 0.5) {
+    level = Math.min(5, baseDifficulty + 1);
+    adjustment = 'nudge up — plateaued, ready for a challenge';
+  } else if (trend === 'declining') {
+    level = Math.max(1, baseDifficulty - 1);
+    adjustment = 'ease off — accuracy declining';
+  }
+
+  const labels = { 1: 'review', 2: 'accessible', 3: 'standard', 4: 'challenging', 5: 'peak' };
+  return { level, label: labels[level] || 'standard', adjustment };
+}
+
+function classifyConcepts(exercises, curriculum) {
+  const solid = [];
+  const shaky = [];
+
+  if (!curriculum?.lessons) return { solid, shaky };
+
+  const completed = curriculum.lessons.filter((l) => l.status === 'completed');
+  for (const lesson of completed.slice(-10)) {
+    const concepts = lesson.concepts || [];
+    const engagement = lesson.engagement;
+    if (engagement === 'correct' || engagement === 'delivered') {
+      solid.push(...concepts);
+    } else if (engagement === 'incorrect') {
+      shaky.push(...concepts);
+    }
+  }
+
+  return {
+    solid: [...new Set(solid)].slice(0, 10),
+    shaky: [...new Set(shaky)].slice(0, 10),
+  };
+}
+
+function generateRecommendations(accuracy, trend, engagement, concepts) {
+  const recs = [];
+
+  if (accuracy > 0.8) recs.push('Skip diagnostic — go straight to a challenge');
+  if (accuracy < 0.4) recs.push('Use more analogies and concrete examples before abstract concepts');
+  if (trend === 'declining') recs.push('Shorter sessions, more encouragement, check if topic is still interesting');
+  if (trend === 'plateaued') recs.push('Vary the exercise format — try teach-back or real-world application');
+  if (engagement === 'low' || engagement === 'declining') recs.push('Lead with a curiosity hook, end with a cliffhanger for next time');
+  if (concepts.shaky.length > 2) recs.push(`Reinforce before proceeding: ${concepts.shaky.slice(0, 3).join(', ')}`);
+  if (!recs.length) recs.push('Standard delivery — student is on track');
+
+  return recs;
+}

--- a/scripts/bot/lesson.js
+++ b/scripts/bot/lesson.js
@@ -1,89 +1,49 @@
 /**
- * Lesson delivery — send teaching chunks naturally, pause only at exercises.
+ * Socratic lesson delivery — multi-turn conversation, not content dump.
  *
  * Flow:
- *   1. Generate full lesson in one Claude call
- *   2. Parse into emoji-anchored chunks
- *   3. Send content chunks with short delays (tutor "typing")
- *   4. On exercise chunk, show numbered answer buttons (1-4) and wait
- *   5. On answer, show feedback, mark complete, write learning.md
+ *   1. Generate lesson plan (1 strong call): diagnostic, concept, follow-up, application
+ *   2. Send diagnostic question → wait for free-text answer
+ *   3. Claude reads answer → tailored response + follow-up → wait
+ *   4. Claude reads answer → feedback + application challenge → wait
+ *   5. Claude reads answer → specific feedback → lesson complete
+ *
+ * Each step is a short Claude call that reads the student's actual answer.
  */
 
 import fs from 'fs';
 import path from 'path';
 import { generate } from './claude.js';
-import { buildTeacherPrompt } from './context.js';
-import { getNextLesson, markLessonComplete, readCurriculum, writeDomainFile, appendMemory } from './state.js';
+import { buildLessonPlanPrompt, buildSocraticResponsePrompt } from '../../lib/core/prompts.js';
+import { buildStudentModel, formatStudentModel } from '../../lib/core/student-model.js';
+import { getNextLesson, markLessonComplete, readCurriculum, readDomainFile, writeDomainFile, readUser, appendMemory } from './state.js';
 import { PATHS } from './config.js';
 import { appendMessage } from './session.js';
 import { registerLessonConcepts } from './spaced-repetition.js';
-import { sleep } from './helpers.js';
+import { TutorState } from '../../lib/core/state.js';
 import { log } from './logger.js';
 
-// ── Exercise state ─────────────────────────────────────────
+const coreState = new TutorState(PATHS.root);
 
-const EXERCISE_STATE_PATH = path.join(PATHS.workspace, 'tutor', 'exercise-state.json');
+// ── Active lessons (in-flight Socratic conversations) ──────
 
-function loadExerciseState() {
-  try {
-    return JSON.parse(fs.readFileSync(EXERCISE_STATE_PATH, 'utf-8'));
-  } catch {
-    return { answers: {}, contexts: {} };
-  }
+const activeLessons = {};
+
+const STEPS = ['diagnostic', 'followUp', 'application'];
+
+export function getActiveLesson(chatId) {
+  return activeLessons[chatId] || null;
 }
 
-function saveExerciseState(state) {
-  const dir = path.dirname(EXERCISE_STATE_PATH);
-  fs.mkdirSync(dir, { recursive: true });
-  const tmp = EXERCISE_STATE_PATH + '.tmp';
-  fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
-  fs.renameSync(tmp, EXERCISE_STATE_PATH);
+export function clearActiveLesson(chatId) {
+  delete activeLessons[chatId];
 }
 
-const exerciseState = loadExerciseState();
-
-export function getCorrectAnswer(topicSlug, day) {
-  return exerciseState.answers[topicSlug + ':' + day];
-}
-
-export function getLessonContext(topicSlug, day) {
-  return exerciseState.contexts[topicSlug + ':' + day];
-}
-
-export function stripAnswerKey(text) {
-  return text
-    .replace(/^\s*(?:correct|answer)\s*(?:is)?\s*[:\s]\s*\(?[A-D]\)?\s*$/gim, '')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-}
-
-// ── Last exercise result (set by callbacks.js) ─────────────
-
-const lastExerciseResults = {};
-
-export function setLastExerciseResult(topicSlug, day, result) {
-  lastExerciseResults[topicSlug + ':' + day] = result;
-}
-
-// ── Pending lessons (waiting for exercise answer) ──────────
-
-const pendingLessons = {};
-
-export function getPendingLesson(chatId) {
-  return pendingLessons[chatId] || null;
-}
-
-function clearPendingLesson(chatId) {
-  delete pendingLessons[chatId];
-}
-
-// ── Main entry: generate and deliver lesson ────────────────
+// ── Main entry: generate plan and send diagnostic ──────────
 
 export async function deliverNextLesson(topicSlug, chatId, channel, skills) {
-  const start = Date.now();
   const lesson = getNextLesson(topicSlug);
   if (!lesson) {
-    log.info({ topic: topicSlug }, 'all lessons completed');
     const curriculum = readCurriculum(topicSlug);
     await channel.sendMessage(chatId, `🎉 <b>You've completed all ${curriculum?.lessons?.length || 0} lessons in ${curriculum?.topic || topicSlug}!</b>\n\nType /quiz for a final review, or /add to start something new.`);
     return;
@@ -92,85 +52,136 @@ export async function deliverNextLesson(topicSlug, chatId, channel, skills) {
   await channel.sendTyping(chatId);
 
   const lessonDay = lesson.day || lesson.lesson;
-  log.info({ topic: topicSlug, lesson_id: lessonDay, title: lesson.title }, 'generating lesson');
+  log.info({ topic: topicSlug, lesson_id: lessonDay, title: lesson.title }, 'generating lesson plan');
 
-  const { system, model, outputMode } = buildTeacherPrompt(skills, lesson, topicSlug);
-  const response = await generate(system, [
-    { role: 'user', content: `Deliver lesson Day ${lessonDay}: "${lesson.title}"` },
-  ], { model, outputMode });
+  // Build student model from learning history
+  const learningMd = readDomainFile(topicSlug, 'learning.md') || '';
+  const curriculum = readCurriculum(topicSlug);
+  const userProfile = readUser();
+  const studentModel = buildStudentModel(learningMd, curriculum, userProfile);
+  const modelText = formatStudentModel(studentModel);
 
-  const chunks = parseLessonChunks(response.text);
+  // Generate lesson plan (1 strong call)
+  const planPrompt = buildLessonPlanPrompt(coreState, skills, lesson, topicSlug, modelText);
+  const planResponse = await generate(planPrompt.system, [
+    { role: 'user', content: `Plan a Socratic lesson for Day ${lessonDay}: "${lesson.title}"` },
+  ], { model: planPrompt.model, outputMode: planPrompt.outputMode });
 
-  // Store exercise context + correct answer
-  exerciseState.contexts[topicSlug + ':' + lessonDay] = {
-    title: lesson.title,
-    concepts: lesson.concepts,
+  let lessonPlan;
+  try {
+    const jsonMatch = planResponse.text.match(/\{[\s\S]*\}/);
+    lessonPlan = JSON.parse(jsonMatch[0]);
+  } catch {
+    log.error({ topic: topicSlug, lessonDay }, 'lesson plan parse failed, falling back');
+    await channel.sendMessage(chatId, `Let's explore: <b>${lesson.title}</b>\n\nWhat do you already know about ${(lesson.concepts || []).join(' and ')}?`);
+    lessonPlan = {
+      diagnostic: `What do you already know about ${(lesson.concepts || []).join(' and ')}?`,
+      concept: lesson.title,
+      followUp: 'Can you think of a real-world example?',
+      application: 'How would you explain this to someone else?',
+      commonMisconceptions: [],
+      goal: lesson.title,
+    };
+  }
+
+  // Store active lesson state
+  activeLessons[chatId] = {
     topicSlug,
+    lessonDay,
+    lesson,
+    plan: lessonPlan,
+    step: 0,
+    history: [],
+    studentModel,
+    startedAt: Date.now(),
   };
-  parseAndStoreAnswer(response.text, topicSlug, lessonDay);
-  saveExerciseState(exerciseState);
 
-  appendMessage(chatId, 'assistant', response.text);
+  log.info({ topic: topicSlug, lessonDay, difficulty: lessonPlan.difficulty, adaptations: lessonPlan.adaptations }, 'lesson plan generated');
 
-  // Send content chunks with natural delays, pause at exercise
-  let hasExercise = false;
-
-  for (let i = 0; i < chunks.length; i++) {
-    const chunk = chunks[i];
-    const isExercise = chunk.anchor === '✏️';
-
-    if (isExercise) {
-      hasExercise = true;
-      const buttons = buildNumberedExerciseButtons(topicSlug, lessonDay, chunk.text);
-      await channel.sendMessage(chatId, stripAnswerKey(chunk.text), { buttons });
-
-      // Store pending lesson — completes when student answers
-      pendingLessons[chatId] = {
-        topicSlug,
-        lessonDay,
-        lesson: { day: lessonDay, title: lesson.title, module: lesson.module, concepts: lesson.concepts },
-      };
-    } else {
-      await channel.sendMessage(chatId, stripAnswerKey(chunk.text));
-      if (i < chunks.length - 1) await sleep(2000);
-    }
-  }
-
-  log.info({ topic: topicSlug, lesson_id: lessonDay, chunks: chunks.length, hasExercise, latency_ms: Date.now() - start }, 'lesson delivered');
-
-  // If no exercise chunk, complete immediately
-  if (!hasExercise) {
-    finishLesson(topicSlug, lessonDay, lesson);
-  }
+  // Send the diagnostic question
+  await channel.sendMessage(chatId, lessonPlan.diagnostic);
+  appendMessage(chatId, 'assistant', lessonPlan.diagnostic);
 }
 
-// ── Complete lesson (called after exercise or if no exercise) ──
+// ── Handle student's answer during a Socratic lesson ───────
 
-function finishLesson(topicSlug, lessonDay, lesson) {
-  appendMemory(`Lesson delivered: Day ${lessonDay} — ${lesson.title} (${topicSlug})`);
-  markLessonComplete(topicSlug, lessonDay, 'delivered');
+export async function handleLessonAnswer(text, chatId, channel) {
+  const active = activeLessons[chatId];
+  if (!active) return false;
+
+  await channel.sendTyping(chatId);
+
+  const stepName = STEPS[active.step];
+  active.history.push({ role: 'user', content: text });
+
+  log.info({ topic: active.topicSlug, lessonDay: active.lessonDay, step: stepName }, 'student answered');
+
+  // Generate Socratic response (cheap call)
+  const user = readUser();
+  const responsePrompt = buildSocraticResponsePrompt(active.plan, text, stepName, user);
+  const response = await generate(responsePrompt.system, [
+    ...active.history,
+  ], { model: responsePrompt.model, outputMode: responsePrompt.outputMode });
+
+  active.history.push({ role: 'assistant', content: response.text });
+  active.step++;
+
+  await channel.sendMessage(chatId, response.text);
+  appendMessage(chatId, 'user', text);
+  appendMessage(chatId, 'assistant', response.text);
+
+  // Check if lesson is complete (after application step)
+  if (active.step >= STEPS.length) {
+    completeSocraticLesson(chatId, active, text);
+  }
+
+  return true;
+}
+
+// ── Complete a Socratic lesson ─────────────────────────────
+
+function completeSocraticLesson(chatId, active, lastAnswer) {
+  const { topicSlug, lessonDay, lesson, plan, studentModel, startedAt } = active;
+
+  // Determine engagement from conversation quality
+  const engagement = assessEngagement(active.history);
+
+  appendMemory(`Socratic lesson completed: Day ${lessonDay} — ${lesson.title} (${topicSlug}). ${active.history.length} exchanges, engagement: ${engagement}`);
+  markLessonComplete(topicSlug, lessonDay, engagement);
 
   if (lesson.concepts?.length) {
     registerLessonConcepts(topicSlug, lesson.concepts);
   }
 
-  writeLearningLog(topicSlug, lesson);
+  writeLearningLog(topicSlug, lesson, active);
+  clearActiveLesson(chatId);
+
+  log.info({
+    topic: topicSlug,
+    lessonDay,
+    exchanges: active.history.length,
+    engagement,
+    duration_ms: Date.now() - startedAt,
+  }, 'socratic lesson complete');
 }
 
-/**
- * Called by callbacks.js after exercise answer or skip.
- */
-export function completeLessonAfterExercise(chatId) {
-  const pending = pendingLessons[chatId];
-  if (pending) {
-    finishLesson(pending.topicSlug, pending.lessonDay, pending.lesson);
-    clearPendingLesson(chatId);
-  }
+// ── Assess engagement from conversation ────────────────────
+
+function assessEngagement(history) {
+  const studentMessages = history.filter((m) => m.role === 'user');
+  if (!studentMessages.length) return 'minimal';
+
+  const avgLength = studentMessages.reduce((sum, m) => sum + m.content.length, 0) / studentMessages.length;
+
+  if (avgLength > 100) return 'high';
+  if (avgLength > 30) return 'engaged';
+  if (avgLength > 10) return 'brief';
+  return 'minimal';
 }
 
-// ── Learning log ───────────────────────────────────────────
+// ── Learning log (enriched with student model) ─────────────
 
-function writeLearningLog(topicSlug, lesson) {
+function writeLearningLog(topicSlug, lesson, active) {
   const curriculum = readCurriculum(topicSlug);
   if (!curriculum) return;
 
@@ -178,99 +189,50 @@ function writeLearningLog(topicSlug, lesson) {
   const pending = curriculum.lessons.filter((l) => l.status === 'pending');
   const nextLesson = pending[0];
   const lessonDay = lesson.day || lesson.lesson;
-  const exerciseResult = lastExerciseResults[topicSlug + ':' + lessonDay] || 'pending';
+  const engagement = assessEngagement(active.history);
+
+  const studentMessages = active.history.filter((m) => m.role === 'user');
+  const exerciseHistory = completed.slice(-5).map((l) => {
+    const e = l.engagement;
+    return e === 'high' || e === 'engaged' || e === 'correct' ? '✓' : '✗';
+  }).join(' ');
 
   const lines = [
     `# Learning Log: ${curriculum.topic || topicSlug}`,
     '',
-    `## Position`,
+    '## Position',
     `- **Last lesson:** Day ${lessonDay} — ${lesson.title}`,
     `- **Next lesson:** ${nextLesson ? `Day ${nextLesson.day || nextLesson.lesson} — ${nextLesson.title}` : 'Curriculum complete'}`,
     `- **Progress:** ${completed.length}/${curriculum.lessons.length} lessons (${Math.round((completed.length / curriculum.lessons.length) * 100)}%)`,
     '',
-    `## Performance`,
-    `- **Last exercise:** ${exerciseResult}`,
+    '## Accuracy Trend',
+    `- **Last 5:** ${exerciseHistory || 'no data yet'}`,
+    `- **Engagement:** ${engagement}`,
     '',
-    `## Session`,
+    '## Session',
     `- **Date:** ${new Date().toISOString().split('T')[0]}`,
     `- **Time:** ${new Date().toLocaleTimeString('en-US', { hour12: false })}`,
+    `- **Exchanges:** ${active.history.length}`,
+    `- **Avg answer length:** ${studentMessages.length ? Math.round(studentMessages.reduce((s, m) => s + m.content.length, 0) / studentMessages.length) : 0} chars`,
     '',
-    `## Notes for Next Session`,
+    '## Notes for Next Session',
     `Last covered: ${lesson.title}. Concepts: ${(lesson.concepts || []).join(', ')}.`,
-  ];
+    active.plan?.goal ? `Goal was: ${active.plan.goal}` : '',
+    engagement === 'minimal' || engagement === 'brief' ? 'Student gave short answers — try more engaging hooks next time.' : '',
+  ].filter(Boolean);
 
   writeDomainFile(topicSlug, 'learning.md', lines.join('\n'));
   log.debug({ topic: topicSlug, lessonDay }, 'learning.md written');
 }
 
-// ── Parse lesson text into chunks by emoji anchors ──────────
+// ── Legacy exports (for callbacks.js compatibility) ────────
 
-const ANCHORS = ['📖', '🧠', '💡', '✏️', '🔗'];
-
-function parseLessonChunks(text) {
-  const chunks = [];
-  const lines = text.split('\n');
-  let current = null;
-
-  for (const line of lines) {
-    const anchor = ANCHORS.find((a) => line.trimStart().startsWith(a));
-    if (anchor) {
-      if (current) chunks.push(current);
-      current = { anchor, text: line + '\n' };
-    } else if (current) {
-      current.text += line + '\n';
-    } else {
-      if (!chunks.length) {
-        current = { anchor: null, text: line + '\n' };
-      }
-    }
-  }
-  if (current) chunks.push(current);
-
-  return chunks.map((c) => ({ ...c, text: c.text.trim() }));
+export function getCorrectAnswer() { return null; }
+export function getLessonContext(topicSlug, day) {
+  return { title: `Lesson ${day}`, concepts: [], topicSlug };
 }
-
-// ── Exercise buttons (numbered 1-4) ────────────────────────
-
-function parseAndStoreAnswer(fullText, topicSlug, day) {
-  const patterns = [
-    /(?:correct|answer)\s*(?:is)?[:\s]*\(?([A-D])\)?/i,
-    /\b([A-D])\b\s*(?:is\s+)?(?:the\s+)?(?:correct|right)\b/i,
-    /✅\s*\(?([A-D])\)?/i,
-    /^[^a-z]*correct[^a-z]*([A-D])\b/im,
-  ];
-  for (const pattern of patterns) {
-    const m = fullText?.match(pattern);
-    if (m) {
-      exerciseState.answers[topicSlug + ':' + day] = m[1].toUpperCase();
-      return;
-    }
-  }
-  log.warn({ day }, 'could not parse correct answer from exercise text');
-}
-
-function buildNumberedExerciseButtons(topicSlug, day, exerciseText) {
-  const labels = parseExerciseOptionLabels(exerciseText);
-
-  const row1 = labels.map((label, i) => ({
-    text: `${i + 1}`,
-    callback_data: `ex:${topicSlug}:${day}:${String.fromCharCode(65 + i)}`,
-  }));
-
-  const row2 = [
-    { text: '💡 Hint', callback_data: `ex:${topicSlug}:${day}:hint` },
-    { text: '⏭ Skip', callback_data: `ex:${topicSlug}:${day}:skip` },
-  ];
-
-  return [row1, row2];
-}
-
-function parseExerciseOptionLabels(text) {
-  const labels = [];
-  const pattern = /\b([A-D])[.):\s]+(.+?)(?:\n|$)/g;
-  let m;
-  while ((m = pattern.exec(text)) !== null) {
-    labels.push(m[2].trim().slice(0, 40));
-  }
-  return labels.length >= 2 ? labels : ['Option 1', 'Option 2', 'Option 3', 'Option 4'];
+export function setLastExerciseResult() {}
+export function completeLessonAfterExercise() {}
+export function stripAnswerKey(text) {
+  return text.replace(/^\s*(?:correct|answer)\s*(?:is)?\s*[:\s]\s*\(?[A-D]\)?\s*$/gim, '').trim();
 }

--- a/scripts/bot/lesson.js
+++ b/scripts/bot/lesson.js
@@ -16,6 +16,7 @@ import path from 'path';
 import { generate } from './claude.js';
 import { buildLessonPlanPrompt, buildSocraticResponsePrompt } from '../../lib/core/prompts.js';
 import { buildStudentModel, formatStudentModel } from '../../lib/core/student-model.js';
+import { evaluatePractice, formatPracticeFeedback, parseDirectives, applyDirectives } from '../../lib/core/deliberate-practice.js';
 import { getNextLesson, markLessonComplete, readCurriculum, readDomainFile, writeDomainFile, readUser, appendMemory } from './state.js';
 import { PATHS } from './config.js';
 import { appendMessage } from './session.js';
@@ -52,17 +53,58 @@ export async function deliverNextLesson(topicSlug, chatId, channel, skills) {
   await channel.sendTyping(chatId);
 
   const lessonDay = lesson.day || lesson.lesson;
-  log.info({ topic: topicSlug, lesson_id: lessonDay, title: lesson.title }, 'generating lesson plan');
-
-  // Build student model from learning history
   const learningMd = readDomainFile(topicSlug, 'learning.md') || '';
   const curriculum = readCurriculum(topicSlug);
   const userProfile = readUser();
+
+  // Read and enforce deliberate practice directives
+  const feedbackMd = readDomainFile(topicSlug, 'practice-feedback.md') || '';
+  const directives = parseDirectives(feedbackMd);
+  const constraints = applyDirectives(directives);
+
+  // BLOCK — if a concept must be retested before advancing
+  if (constraints.blocked) {
+    log.info({ topic: topicSlug, blocked: constraints.blockedConcept }, 'blocked by deliberate practice');
+    await channel.sendMessage(chatId, `Before we move on, let's make sure you've got <b>${constraints.blockedConcept}</b> down.\n\nExplain it to me in your own words — what is it and why does it matter?`);
+
+    activeLessons[chatId] = {
+      topicSlug,
+      lessonDay,
+      lesson,
+      plan: {
+        diagnostic: `Explain "${constraints.blockedConcept}" in your own words.`,
+        concept: `This concept is foundational for what comes next.`,
+        followUp: `Can you give a concrete example of ${constraints.blockedConcept}?`,
+        application: `How would you use this concept in a real situation?`,
+        commonMisconceptions: [],
+        goal: `Demonstrate solid understanding of ${constraints.blockedConcept}`,
+      },
+      step: 0,
+      history: [],
+      studentModel: buildStudentModel(learningMd, curriculum, userProfile),
+      startedAt: Date.now(),
+      isReview: true,
+      reviewConcept: constraints.blockedConcept,
+    };
+    return;
+  }
+
+  log.info({ topic: topicSlug, lesson_id: lessonDay, title: lesson.title, constraints }, 'generating lesson plan');
+
+  // Build student model + directives context
   const studentModel = buildStudentModel(learningMd, curriculum, userProfile);
   const modelText = formatStudentModel(studentModel);
 
+  // Build directive context for the lesson planner
+  const directiveContext = [];
+  if (constraints.difficultyOverride) directiveContext.push(`DIFFICULTY OVERRIDE: set to ${constraints.difficultyOverride}`);
+  if (constraints.formatOverride) directiveContext.push(`FORMAT OVERRIDE: use ${constraints.formatOverride} format`);
+  if (constraints.revisitConcepts.length) directiveContext.push(`REVISIT: weave in review of: ${constraints.revisitConcepts.join(', ')}`);
+  if (constraints.requireGoal) directiveContext.push('GOAL REQUIRED: open with explicit testable goal, close with self-assessment');
+  const directiveText = directiveContext.length ? `\n\n## Deliberate Practice Directives\n${directiveContext.join('\n')}` : '';
+
   // Generate lesson plan (1 strong call)
-  const planPrompt = buildLessonPlanPrompt(coreState, skills, lesson, topicSlug, modelText);
+  const planPrompt = buildLessonPlanPrompt(coreState, skills, lesson, topicSlug, modelText + directiveText);
   const planResponse = await generate(planPrompt.system, [
     { role: 'user', content: `Plan a Socratic lesson for Day ${lessonDay}: "${lesson.title}"` },
   ], { model: planPrompt.model, outputMode: planPrompt.outputMode });
@@ -143,22 +185,45 @@ export async function handleLessonAnswer(text, chatId, channel) {
 function completeSocraticLesson(chatId, active, lastAnswer) {
   const { topicSlug, lessonDay, lesson, plan, studentModel, startedAt } = active;
 
-  // Determine engagement from conversation quality
   const engagement = assessEngagement(active.history);
 
-  appendMemory(`Socratic lesson completed: Day ${lessonDay} — ${lesson.title} (${topicSlug}). ${active.history.length} exchanges, engagement: ${engagement}`);
-  markLessonComplete(topicSlug, lessonDay, engagement);
+  // Skip marking complete if this was a review (BLOCK directive)
+  if (!active.isReview) {
+    appendMemory(`Socratic lesson completed: Day ${lessonDay} — ${lesson.title} (${topicSlug}). ${active.history.length} exchanges, engagement: ${engagement}`);
+    markLessonComplete(topicSlug, lessonDay, engagement);
 
-  if (lesson.concepts?.length) {
-    registerLessonConcepts(topicSlug, lesson.concepts);
+    if (lesson.concepts?.length) {
+      registerLessonConcepts(topicSlug, lesson.concepts);
+    }
+  } else {
+    appendMemory(`Review completed: ${active.reviewConcept} (${topicSlug}). Engagement: ${engagement}`);
   }
 
   writeLearningLog(topicSlug, lesson, active);
+
+  // Run DeliberatePractitioner — evaluate and write directives
+  try {
+    const learningMd = readDomainFile(topicSlug, 'learning.md') || '';
+    const curriculum = readCurriculum(topicSlug);
+    const userProfile = readUser();
+    const evaluation = evaluatePractice(learningMd, curriculum, userProfile);
+    const feedback = formatPracticeFeedback(evaluation, curriculum?.topic || topicSlug);
+    writeDomainFile(topicSlug, 'practice-feedback.md', feedback);
+
+    const criticalDirectives = evaluation.directives.filter((d) => d.priority === 'critical' || d.priority === 'high');
+    if (criticalDirectives.length) {
+      log.info({ topic: topicSlug, directives: criticalDirectives.map((d) => `${d.type}:${d.target}`) }, 'deliberate practice directives issued');
+    }
+  } catch (err) {
+    log.warn({ err, topic: topicSlug }, 'deliberate practice evaluation failed');
+  }
+
   clearActiveLesson(chatId);
 
   log.info({
     topic: topicSlug,
     lessonDay,
+    isReview: !!active.isReview,
     exchanges: active.history.length,
     engagement,
     duration_ms: Date.now() - startedAt,

--- a/scripts/bot/router.js
+++ b/scripts/bot/router.js
@@ -7,6 +7,7 @@ import { handleCommand, isCommand } from './commands.js';
 import { handleCallback } from './callbacks.js';
 import { handleOnboarding, isOnboarding } from './onboarding.js';
 import { handleChat } from './chat.js';
+import { getActiveLesson, handleLessonAnswer } from './lesson.js';
 import { isGroupChat, addGroupMember } from './state.js';
 import { runWithReqId, log } from './logger.js';
 
@@ -47,6 +48,11 @@ export async function route(update, channel, skills) {
     // Commands take priority
     if (isCommand(text)) {
       return handleCommand(text, chatId, channel, skills);
+    }
+
+    // Active Socratic lesson — route free-text answers to lesson handler
+    if (getActiveLesson(chatId)) {
+      return handleLessonAnswer(text, chatId, channel);
     }
 
     // Onboarding flow (if active)


### PR DESCRIPTION
## Summary

Redesign lesson delivery from passive content dump to multi-turn Socratic conversation with deliberate practice.

**Before:** 📖 read → 🧠 read → 💡 read → ✏️ pick A/B/C/D. Student passive for 80% of the interaction.

**After:** Tutor asks → student thinks and answers → tutor adapts → student applies. Every message ends with a question. Student types more than the tutor.

## Changes

- **Student model** (`lib/core/student-model.js`): computes accuracy trend, difficulty adjustment, engagement signals from learning history
- **Lesson plan generation**: one strong call produces diagnostic, concept, follow-up, application — calibrated to this student's current state
- **Socratic delivery**: 3 cheap calls that read the student's actual answers and adapt
- **Router**: detects active lesson, routes free-text to lesson handler
- **Enriched learning.md**: tracks exchange count, answer length, engagement

## Deliberate practice

| Principle | Implementation |
|---|---|
| Target weaknesses | Student model identifies shaky concepts |
| Stretch zone | Difficulty computed from accuracy trend |
| Immediate specific feedback | Claude reads actual answers |
| Repetition with refinement | Shaky concepts flagged for review |
| Specific goals | Lesson plan has explicit goal statement |

## Test plan

- [ ] Start bot, /add a topic, /next — verify diagnostic question (not content dump)
- [ ] Answer the diagnostic — verify tailored response + follow-up
- [ ] Answer follow-up — verify application challenge
- [ ] Answer application — verify lesson completes, learning.md written
- [ ] Run /next again — verify student model influences next lesson plan
- [ ] Give wrong answers — verify difficulty drops

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)